### PR TITLE
Include AcGD*, AcGM1, AcGQ1b, AcGT1b, APCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ build/
 calicolipidlibrary.egg-info/
 calicolipidlibrary/__pycache__/
 calicolipidlibrary/*.pyc
+tests/__pycache__/
+tests/*.pyc
 *.msp
 .DS_Store

--- a/calicolipidlibrary/AcGD1b.py
+++ b/calicolipidlibrary/AcGD1b.py
@@ -185,9 +185,9 @@ class AcGD1b(SphingoLipid):
 
 
 
-x  = AcGD1b("AcGD1b",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
-print x.printNist()
-
-
-x  = AcGD1b("AcGD1b",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
-print x.printNist()
+# x  = AcGD1b("AcGD1b",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
+# print x.printNist()
+#
+#
+# x  = AcGD1b("AcGD1b",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
+# print x.printNist()

--- a/calicolipidlibrary/AcGD2.py
+++ b/calicolipidlibrary/AcGD2.py
@@ -152,6 +152,6 @@ class AcGD2(SphingoLipid):
 
 
 
-x  = AcGD2("AcGD2",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
-print x.printNist()
+# x  = AcGD2("AcGD2",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
+# print x.printNist()
 

--- a/calicolipidlibrary/AcGD3.py
+++ b/calicolipidlibrary/AcGD3.py
@@ -114,7 +114,7 @@ class AcGD3(SphingoLipid):
 
 
 
-x  = AcGD3("AcGD3",[[18,1,1], [23,0,0]],  adduct="[M+H]+")
-print x.printNist()
+# x  = AcGD3("AcGD3",[[18,1,1], [23,0,0]],  adduct="[M+H]+")
+# print x.printNist()
 
 

--- a/calicolipidlibrary/AcGM1.py
+++ b/calicolipidlibrary/AcGM1.py
@@ -85,9 +85,9 @@ class AcGM1(SphingoLipid):
 
 
 
-x  = AcGM1("AcGM1",[[18,1,1], [18,0,0]],  adduct="[M-H]-")
-print x.printNist()
-
-
-x  = AcGM1("AcGM1",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
-print x.printNist()
+# x  = AcGM1("AcGM1",[[18,1,1], [18,0,0]],  adduct="[M-H]-")
+# print x.printNist()
+#
+#
+# x  = AcGM1("AcGM1",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
+# print x.printNist()

--- a/calicolipidlibrary/AcGQ1b.py
+++ b/calicolipidlibrary/AcGQ1b.py
@@ -152,5 +152,5 @@ class AcGQ1b(SphingoLipid):
 
 
 
-x  = AcGQ1b("AcGQ1b",[[18,1,1], [18,0,0]],  adduct="[M+2H]2+")
-print x.printNist()
+# x  = AcGQ1b("AcGQ1b",[[18,1,1], [18,0,0]],  adduct="[M+2H]2+")
+# print x.printNist()

--- a/calicolipidlibrary/AcGT1b.py
+++ b/calicolipidlibrary/AcGT1b.py
@@ -147,16 +147,16 @@ class AcGT1b(SphingoLipid):
 
 
 
-x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
-print x.printNist()
-
-
-
-x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+2H]2+")
-print x.printNist()
-
-
-
-x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
-print x.printNist()
+# x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+H]+")
+# print x.printNist()
+#
+#
+#
+# x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+2H]2+")
+# print x.printNist()
+#
+#
+#
+# x  = AcGT1b("AcGT1b",[[18,1,1], [18,0,0]],  adduct="[M+Na]+")
+# print x.printNist()
 

--- a/calicolipidlibrary/__init__.py
+++ b/calicolipidlibrary/__init__.py
@@ -1,9 +1,17 @@
+from AcGD1a import *
+from AcGD1b import *
+from AcGD2 import *
+from AcGD3 import *
+from AcGM1 import *
 from AcGM2 import *
 from AcGM3 import *
+from AcGQ1b import *
+from AcGT1b import *
 from Alkyl_LPC import *
 from Alkyl_LPE import *
 from Alkyl_LPS import *
 from Alkyl_PC import *
+from APCS import *
 from Alkyl_PE import *
 from Alkyl_PS import *
 from BDP import*

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -53,68 +53,76 @@ ALL_ADDUCTS = POS_ADDUCTS.copy()
 ALL_ADDUCTS |= NEG_ADDUCTS.copy()
 
 ALL_LIPID_CLASSES = {
+    "AcGD1a",
+    "AcGD1b",
+    "AcGD2",
+    "AcGD3",
+    "AcGM1",                # 5
     "AcGM2",
     "AcGM3",
-    "Alkyl_LPC",
+    "AcGQ1b",
+    "AcGT1b",
+    "Alkyl_LPC",            # 10
     "Alkyl_LPE",
-    "Alkyl_LPS",                # 5
+    "Alkyl_LPS",
     "Alkyl_PC",
     "Alkyl_PE",
-    "Alkyl_PS",
+    "Alkyl_PS",             # 15
+    "APCS",
     "BDP",
-    "BMP",                      # 10
+    "BMP",
     "Carn",
-    "CDP_DG",
+    "CDP_DG",               # 20
     "CE",
     "Ceramide",
-    "Ceramide_P",               # 15
+    "Ceramide_P",
     "CL",
-    "CPE",
+    "CPE",                  # 25
     "CPI",
     "DG",
-    "DGDG",                     # 20
+    "DGDG",
     "DGTS",
-    "DMPE",
+    "DMPE",                    # 30
     "ErgE",
     "Ethanolamine",
-    "FA",                       # 25
+    "FA",
     "FAHFA",
-	"GB3",
+    "GB3",                  # 35
     "GcGM2",
     "GcGM3",
-    "HemiBMP",					# 30
+    "HemiBMP",
     "HexCer",
-    "LacCer",
+    "LacCer",               # 40
     "LCB_P",
     "LCB",
-    "LPA",                      # 35
+    "LPA",
     "LPC",
-    "LPE",
+    "LPE",                  # 45
     "LPG",
     "LPI",
-    "LPS",                   	# 40
+    "LPS",
     "LysoCL",
-    "LysoCPE",
+    "LysoCPE",              # 50
     "LysoCPI",
     "LysoHexCer",
-    "LysoSM",                   # 45
+    "LysoSM",
     "MG",
-    "MGDG",
+    "MGDG",                 # 55
     "MIP2C",
     "MIPC",
-    "MMPE",                		# 50
+    "MMPE",
     "N_Acyl_PE",
-    "N_Acyl_PS",
+    "N_Acyl_PS",            # 60
     "PA",
     "PC",
-    "PE",                       # 55
+    "PE",
     "PG",
-    "PI",
+    "PI",                   # 65
     "PS",
     "SM",
-    "Sulfatide",                # 60
+    "Sulfatide",
     "Taurine",
-    "TG",
+    "TG",                   # 70
 }
 
 def MW(form):  # calc MW from string that is chemical formula

--- a/tests/test_library_generation.py
+++ b/tests/test_library_generation.py
@@ -24,14 +24,23 @@ def checksum_for_generated_library(lipid_cls, ion):
     os.unlink(f.name)  # delete the file
     return csum
 
-test_params = [(AcGM2,         "ea411225fdcfc944932266c142443710", "0f72e21f828f93b0ac1bb9ceba9865f2"),
+
+test_params = [(AcGD1a,        "fc8ebe9001dcf1056e93015d8270a6b6", "06c624e96cbf05971111c3be6a460c6a"),
+               (AcGD1b,        "343937f9080d05d1974b3e697674dac0", "7c6e77434b56eb441a479e1a1dbbdd30"),
+               (AcGD2,         "1c8578a37d41985f7d9e1e304abe4f8a", "c3b798eda950260e7edacbba2aecba3a"),
+               (AcGD3,         "60924d18ccb5a386f2a2028871a578c5", "74b2fc5aa05ca1f0c2224324f0b6eb5f"),
+               (AcGM1,         "8b919e6c5f34ca982971792b15aa8cf1", "c45c914368f6becdf6af2a80422ddf97"),
+               (AcGM2,         "ea411225fdcfc944932266c142443710", "0f72e21f828f93b0ac1bb9ceba9865f2"),
                (AcGM3,         "8178e54d2ee356d7c17a1eacda122835", "57f7bd38ec39732681216b2aebdbbccc"),
+               (AcGQ1b,        "78da4a0c4b95097916e4fa5a53284a38", "3349055c0ffcdcf49764218b61eae091"),
+               (AcGT1b,        "428559f8e587b8bd964b63a4ede9a49c", "8bd31dcee37bfc0d48d455a06431563d"),
                (Alkyl_LPC,     "38fa54a34da19d9505e041379056a9b6", "4edda981da32bd3950ab7bc0bd7f2864"),
                (Alkyl_LPE,     "a576f9fe68ad2abd2f6e8621a39e62a7", "a07f86b35d7679ecc2482b2cc8c0b5f9"),
                (Alkyl_LPS,     "c96a3a1a59dbfe36ae88b4a87895af53", "7e8562de40b11cf4a3e1bdb1a8144eee"),
                (Alkyl_PC,      "4bc6a0b3a5dcdb025b81fad96db4c501", "b90f66dd169c469b8930ca1bfd761c82"),
                (Alkyl_PE,      "a84b83dafed85324a7dced10f0b3b667", "c7085349a6398493c6cf5332b83a179b"),
                (Alkyl_PS,      "22aab1538df291b1e0296a0b6fc2181c", "af897221d1952d72be5651fbf1fa7457"),
+               (APCS,          "2a302e5a510f4258fa9832f3dc6c5c58", "e79bc0202960d921181c5622dfa840dd"),
                (BDP,           "f485fe58e198388d167cd0c9aecea5dd", "6d4358098013f6665bb90c5e99e12076"),
                (BMP,           "2a17651f16575da65f4b5c3dac0a6ac4", "1c1234f91884035c24705e4ff821a477"),
                (Carn,          "c7814cd5d1f354354a8047f6daf8550f", "bd144d4e286056405e5488e3ad308e24"),


### PR DESCRIPTION
### Description of your changes
Including eight lipids that have code but were not called out in `__init__.py` or ALL_LIPID_CLASSES

### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation add / update

### (If applicable) How has this been tested?
- Verified that all 62 previous lipids' output is unchanged by these inclusions
- Added 8 more rudimentary (checksum-based) tests to cover these inclusions