### PR TITLE
changes to remove positional isomers for glycerolipids with 3+ chains…

### DIFF
--- a/calicolipidlibrary/CE.py
+++ b/calicolipidlibrary/CE.py
@@ -2,7 +2,7 @@ from lipidRules import *
 
 
 class CE(singleAcyl):
-    pos_adduct_set = ["[M+Na]+", "[M+K]+", "[M+NH4]+", "[M+Li]+"]
+    pos_adduct_set = ["[M+Na]+", "[M+NH4]+"]
 
     def theoreticalDigest(self):
         FRAGMENTS = []

--- a/calicolipidlibrary/OAcylCeramide.py
+++ b/calicolipidlibrary/OAcylCeramide.py
@@ -1,0 +1,26 @@
+from lipidRules import *
+
+class OAcylCeramide(AcylSphingoLipid):
+    pos_adduct_set = ["[M+H]+"]
+    def theoreticalDigest(self):
+        FRAGMENTS = []
+        adduct = self.adduct
+
+        MASS = MW_list(self.MF())
+        PREC = MASS + ADDUCT[self.adduct]
+
+        if adduct in POS_ADDUCTS:
+            if adduct == "[M+H]+":
+                FRAGMENTS.append([PREC, 2, "precursor"])
+                FRAGMENTS.append([PREC - H2O, 900, "pre-H2O"]) #a
+                FRAGMENTS.append([PREC - NL(self.chains[2]), 75, "pre-acyl"]) #b
+                FRAGMENTS.append(
+                    [PREC - NL(self.chains[2]) - H2O, 750, "pre-acyl-water"] #c
+                )
+                FRAGMENTS.append([PREC - NL(self.chains[1]) - NL(self.chains[2]), 1000, "sphingoid base"]) #e
+                FRAGMENTS.append([PREC - NL(self.chains[1]) - NL(self.chains[2]) - MW("NH3"), 50, "sphingoid base - NH3"])
+
+                FRAGMENTS.append([NL(self.chains[1]) - H2O + MW("NC2H3") + ADDUCT[adduct], 80, "sn2 amide + CH2"]) #d
+                FRAGMENTS.append([NL(self.chains[2]) -H2O + MW("NH") + ADDUCT[adduct], 50, "sn2 amide"]) #f
+
+        return FRAGMENTS

--- a/calicolipidlibrary/__init__.py
+++ b/calicolipidlibrary/__init__.py
@@ -1,3 +1,4 @@
+from OAcylCeramide import  *
 from AcGD1a import *
 from AcGD1b import *
 from AcGD2 import *

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -435,17 +435,15 @@ class Lipid:
         self.adduct = ""
         self.lipidName = ""
 
-    # for standards C30 method
-    # neg_adduct_set = ["[M-H]-", "[M+FA-H]-", "[M+Cl]-"]
-    # pos_adduct_set = ["[M+H]+", "[M+Na]+", "[M+K]+", "[M+NH4]+"]
-    # NCE = "20,30,40"
 
-    # for DI libraries
+    # complete set of adducts, for future reference for DI libraries
     #neg_adduct_set = ["[M-H]-", "[M+Cl]-", "[M+37Cl]-", "[M+FA-H]-", "[M+AcOH-H]-"]
     #pos_adduct_set = ["[M+Li]+", "[M+H]+", "[M+Na]+", "[M+NH4]+", "[M+K]+"]
+
+    #current set of adducts we wish to search for
     neg_adduct_set = ["[M-H]-","[M+FA-H]-"]
     pos_adduct_set = ["[M+H]+", "[M+Na]+", "[M+NH4]+"]
-    NCE = ""
+    NCE = "20,30,40"
 
     # lipidclass is one of the above listed lipid backbones
     # chains is a list of lists, where each member list is [#carbons, #double bond, #hydroxyls] for one carbon chain in the lipid


### PR DESCRIPTION
….  Added 1-O-acylceramide class.

### Description of your changes
Added OACylCeramides class to CLL
Modified smp generation so that lipid with 3+ acyl groups don't produce structural isomers, and use the "_" nomenclature instead of the "/" nomenclature in lipid names.  

### Issue ticket number and link
mass_spec ticket 1631

### Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Backwards Incompatible?
- [ ] Refactoring / code clean-up
- [ ] Documentation add / update
- [ ] Automated Test
- [ ] Other (please specify)

### (If applicable) How has this been tested?
I looked at the output.  It seemed okay.  