### PR TITLE
Various improvements related to adding SMILES to the database

### DIFF
--- a/calicolipidlibrary/CDP_DG.py
+++ b/calicolipidlibrary/CDP_DG.py
@@ -2,7 +2,7 @@ from lipidRules import *
 
 
 class CDP_DG(GPL):
-    pos_adduct_set = ["[M+H]+", "[M+Na]+", "[M+K]+"]
+    pos_adduct_set = ["[M+H]+", "[M+Na]+"]
 
     def theoreticalDigest(self):
         FRAGMENTS = []

--- a/calicolipidlibrary/CPE.py
+++ b/calicolipidlibrary/CPE.py
@@ -1,7 +1,7 @@
 from lipidRules import *
 
 
-class CPE(SphingoLipid):
+class CPE(PhytoSphingoLipid):
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/CPI.py
+++ b/calicolipidlibrary/CPI.py
@@ -1,7 +1,7 @@
 from lipidRules import *
 
 
-class CPI(SphingoLipid):
+class CPI(PhytoSphingoLipid):
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/Ceramide.py
+++ b/calicolipidlibrary/Ceramide.py
@@ -3,6 +3,30 @@ from lipidRules import *
 
 # need to fix nomenclature
 class Ceramide(SphingoLipid):
+
+    chain1_ranges = []
+    for c in range(14, 23):
+        for d in range(0, 2):
+            for h in range(1, 3):
+                if (h > 1 and d > 0):
+                    continue
+                chain1_ranges.append([c, d, h])
+
+    chain2_ranges = []
+    for c in [2] + list(range(14, 25)):
+        for d in range(0, 7):
+            for h in range(0, 2):
+                if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                    continue
+                if (h > 0 and c == 2):
+                    continue
+                chain2_ranges.append([c, d, h])
+
+    chain_sets = []
+    for c1 in chain1_ranges:
+        for c2 in chain2_ranges:
+            chain_sets.append([c1, c2])
+
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/DG.py
+++ b/calicolipidlibrary/DG.py
@@ -2,7 +2,7 @@ from lipidRules import *
 
 
 class DG(GPL):
-    pos_adduct_set = ["[M+Na]+", "[M+K]+", "[M+NH4]+", "[M+Li]+"]
+    pos_adduct_set = ["[M+Na]+","[M+NH4]+"]
 
     def theoreticalDigest(self):
         FRAGMENTS = []

--- a/calicolipidlibrary/LCB.py
+++ b/calicolipidlibrary/LCB.py
@@ -2,6 +2,19 @@ from lipidRules import *
 
 
 class LCB(Lipid):
+
+    chain1_ranges = []
+    for c in range(14, 23):
+        for d in range(0, 3):
+            for h in range(0, 3):
+                if (h == 2 and d > 0):
+                    continue
+                chain1_ranges.append([c, d, h])
+    chain_sets = []
+    for c1 in chain1_ranges:
+        chain_sets.append([c1])
+
+
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/LCB.py
+++ b/calicolipidlibrary/LCB.py
@@ -1,7 +1,7 @@
 from lipidRules import *
 
 
-class LCB(LysoSphingoLipid):
+class LCB(Lipid):
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/MIP2C.py
+++ b/calicolipidlibrary/MIP2C.py
@@ -1,7 +1,7 @@
 from lipidRules import *
 
 
-class MIP2C(SphingoLipid):
+class MIP2C(PhytoSphingoLipid):
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/MIPC.py
+++ b/calicolipidlibrary/MIPC.py
@@ -1,7 +1,7 @@
 from lipidRules import *
 
 
-class MIPC(SphingoLipid):
+class MIPC(PhytoSphingoLipid):
     def theoreticalDigest(self):
         FRAGMENTS = []
         adduct = self.adduct

--- a/calicolipidlibrary/OAcylCeramide.py
+++ b/calicolipidlibrary/OAcylCeramide.py
@@ -1,5 +1,6 @@
 from lipidRules import *
 
+#For the purposes of this class, I am defining the O-Acyl as the sn3 = self.chains[2]
 class OAcylCeramide(AcylSphingoLipid):
     pos_adduct_set = ["[M+H]+"]
     def theoreticalDigest(self):

--- a/calicolipidlibrary/TG.py
+++ b/calicolipidlibrary/TG.py
@@ -3,7 +3,7 @@ from lipidRules import *
 
 
 class TG(Triglyceride):
-    pos_adduct_set = ["[M+Na]+", "[M+K]+", "[M+NH4]+", "[M+Li]+"]
+    pos_adduct_set = ["[M+Na]+", "[M+NH4]+"]
 
     def theoreticalDigest(self):
         FRAGMENTS = []

--- a/calicolipidlibrary/create_smiles.py
+++ b/calicolipidlibrary/create_smiles.py
@@ -247,15 +247,16 @@ def get_sphingolipid_smiles(lipidclass, sn_smiles, chains):
 
     headgroup_smiles_3OH = { #for t LCBs, like t18:0
         "Ceramide": "[C@@H](O)[C@@H](O)[C@H](CO)NC(=O)",
+        "Ceramide_P": "(O)[C@@H](O)[C@H](COP(O)(O)=O)NC(=O)",
+        "CPE": "C(O)[C@@H](O)[C@H](COP(=O)(O)OCCN)NC(=O)",
+        "CPI": "C(O)[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)NC(=O)",
         "LCB": "[C@H]([C@H]([C@H](CO)N)O)O",
         "LCB_P": "[C@H]([C@H]([C@H](COP(=O)(O)O)N)O)O",
         "LysoCPE": "C(O)[C@@H](O)[C@H](COP(=O)(O)OCCN)N",
         "LysoCPI": "C(O)[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)N",
         "LysoHexCer": "C(O)[C@H]([C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O)O)O)N)O",
-        "CPI": "C(O)[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)NC(=O)",
         "MIP2C": "[C@@H](O)[C@@H](O)[C@H](COP(O)(=O)O[C@H]1[C@@H]([C@H]([C@H](O)[C@H]([C@H]1O)O[C@H]1[C@H]([C@@H](O)[C@@H]([C@@H](COP(=O)(O)OC2[C@@H]([C@@H](O)C([C@H]([C@H]2O)O)O)O)O1)O)O)O)O)NC(=O)",
         "MIPC": "C(O)[C@@H](O)[C@H](COP(=O)(O)O[C@@H]1[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H]1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]1O)NC(=O)",
-        "Ceramide_P": "(O)[C@@H](O)[C@H](COP(O)(O)=O)NC(=O)",
         "LysoSM": "C(O)[C@H]([C@H](COP(=O)([O-])OCC[N+](C)(C)C)N)O",
 
     }

--- a/calicolipidlibrary/create_smiles.py
+++ b/calicolipidlibrary/create_smiles.py
@@ -10,7 +10,7 @@ acyl_db_table = {
 for c in range(0,37):
     acyl_db_table[c] = {}
     for d in range(0,7):
-        if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+        if (c > 5 and c < 22 and d > (c - 5) / 3): # or (c < 6 and d > 0):
             continue
         match d:  # #db
             case 0:
@@ -21,12 +21,15 @@ for c in range(0,37):
                 else:
                     acyl_db_table[c][d] = [9]
             case 2:
-                if c < 14:
+                if c < 16:
                     acyl_db_table[c][d] = [4,7]
                 else:
                     acyl_db_table[c][d] = [9 ,12]
             case 3:
-                acyl_db_table[c][d] = [5, 9 ,12]
+                if c < 18:
+                    acyl_db_table[c][d] = [4, 7, 10]
+                else:
+                    acyl_db_table[c][d] = [9 ,12, 15]
             case 4:
                 acyl_db_table[c][d] = [5,8,11,14]
             case 5:
@@ -70,7 +73,7 @@ for c in range(14, 37):
 
 def convert_to_random_smiles(smiles_str):
     random_smiles = Chem.MolToSmiles(Chem.MolFromSmiles(smiles_str), isomericSmiles=True, doRandom=True)
-    while(random_smiles[0] != 'C' or random_smiles[-1] != 'C' or random_smiles[1] != 'C'):
+    while(random_smiles[0] != 'C'  or random_smiles[1] != 'C' or random_smiles[-1] != 'C'):
         random_smiles = Chem.MolToSmiles(Chem.MolFromSmiles(smiles_str), isomericSmiles=True, doRandom=True)
     return random_smiles
 
@@ -96,7 +99,7 @@ def add_dbs(smile_str, position_list, type): #positions use delta-# notation, so
 
 def add_hydroxyl(smile_str, position):
     smile_str_list = list(smile_str)
-    if len(smile_str_list) < position:
+    if len(smile_str_list)  < position:
         return smile_str
     smile_str_list.insert(-(position-1), "(O)")
     new_smile_str = ''.join(smile_str_list)
@@ -163,25 +166,70 @@ def get_HemiBMP_smiles(lipidclass, sn_smiles):
     return complete_smiles
 
 
+def get_OAcylCeramide_smiles(lipidclass, sn_smiles):
+
+    sn1_smiles = reverse_acyl_smiles(sn_smiles[0])[:-3] # reversed because at the other end of the smiles
+    sn2_smiles = (sn_smiles[1])  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[:-1]
+
+    complete_smiles = sn2_smiles + "(=O)OC[C@H](NC(=O)" + sn3_smiles + ")[C@H](O)" + \
+                      sn1_smiles
+    #print(complete_smiles)
+    return complete_smiles
+
+
+
+def get_N_Acyl_PE_smiles(lipidclass, sn_smiles):
+    sn1_smiles = reverse_acyl_smiles(sn_smiles[0]) # reversed because at the other end of the smiles
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])  # reversed because at the other end of the smiles
+    sn3_smiles = sn_smiles[2]
+
+    complete_smiles = sn3_smiles + "(=O)NCCOP(O)(=O)OC[C@@H](COC(" + sn1_smiles[:-1] + ")=O)OC(=O)" + sn2_smiles[:-1]
+
+    #"CCCCCCCCCCCCCCCC(=O)NCCOP(O)(=O)OC[C@@H](COC(CCCCC)=O)OC(=O)C"
+
+
+    #complete_smiles = sn1_smiles + "(=O)OC[C@H](COP(O)(=O)OC[C@H](N" + sn3_smiles + ")C(O)=O)OC(=O)" + sn2_smiles[1:]
+
+    return complete_smiles
+
+
+
+def get_N_Acyl_PS_smiles(lipidclass, sn_smiles):
+    sn1_smiles = reverse_acyl_smiles(sn_smiles[0]) # reversed because at the other end of the smiles
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])  # reversed because at the other end of the smiles
+    sn3_smiles = sn_smiles[2]
+
+    complete_smiles = sn3_smiles + "(=O)N[C@@H](CO)C(=O)COP(=O)(O)" + sn2_smiles + "(=O)OCC(O)" + \
+                      sn1_smiles[:-1] + "(=O)CO"
+    return complete_smiles
+
+
 
 def get_sphingolipid_smiles(lipidclass, sn_smiles, chains):
+    headgroup_smiles_1OH = { #for m LCBs, like m18:1
+        # lipidclass:   #headgroup smiles
 
-
-    headgroup_smiles_1OH = { #m lipids, like m18:1
         "Ceramide": "[C@@H](O)[C@H](C)NC(=O)",
         "LCB": "[C@@H](O)[C@H](C)N",
 
     }
 
-    headgroup_smiles_2OH = { #d lipids, like d18:1
-        # sphingolipids
-        "AcGM2": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
-        "AcGM3": "[C@@H](O)[C@H](CO[C@@H]1OC(CO)[C@@H](O[C@@H]2OC(CO)[C@H](O)[C@H](O[C@]3(C(=O)O)CC(O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O3)C2O)[C@H](O)C1O)NC(=O)",
+    headgroup_smiles_2OH = { #for d LCBs, like d18:1
+        # lipidclass:   #headgroup smiles
+        "AcGD1a": '[C@@H](O)[C@H](CO[C@H]1[C@@H]([C@@H](O)[C@@H]([C@H](O1)CO)O[C@@H]1O[C@H](CO)[C@H](O[C@@H]2O[C@H](CO)[C@@H]([C@H](O[C@H]3[C@@H]([C@H]([C@@H](O)[C@H](O3)CO)O[C@]3(OC([C@@H]([C@H](O)CO)O)[C@H](NC(C)=O)[C@@H](O)C3)C(O)=O)O)[C@H]2CC(=O)C)O)[C@@H]([C@H]1O)O[C@@]1(C[C@@H]([C@@H](NC(C)=O)C(O1)[C@H](O)[C@H](O)CO)O)C(O)=O)O)NC(=O)',
+        "AcGD1b": '[C@@H](O)[C@H](CO[C@@H]1O[C@@H]([C@@H](O[C@H]2[C@H](O)[C@H]([C@H]([C@@H](CO)O2)O[C@H]2[C@H](CC(=O)C)[C@@H](O[C@H]3[C@@H]([C@H]([C@H]([C@H](O3)CO)O)O)O)[C@H]([C@@H](CO)O2)O)O[C@@]2(C[C@H](O)[C@@H](NC(C)=O)C([C@@H]([C@@H](CO)O[C@@]3(C[C@H](O)[C@H](C([C@H](O)[C@@H](CO)O)O3)NC(=O)C)C(=O)O)O)O2)C(O)=O)[C@H](O)[C@H]1O)CO)NC(=O)',
+        "AcGD2": '[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)C([C@H](O)[C@@H](CO)O[C@]4(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O4)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)',
+        "AcGD3": '[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)C([C@H](O)[C@@H](CO)O[C@]4(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O4)O3)[C@H]2O)[C@H](O)C1O)NC(=O)',
+        "AcGM1": '[C@@H](O)[C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O[C@@H]1O[C@H](CO)[C@@H]([C@H](O[C@]2(C(O)=O)C[C@H](O)[C@@H](NC(=O)C)[C@H]([C@@H]([C@H](O)CO)O)O2)[C@H]1O)O[C@H]1[C@@H]([C@H]([C@@H](O)[C@@H](CO)O1)O[C@H]1[C@H](O)[C@@H](O)[C@H]([C@H](O1)CO)O)NC(=O)C)O)O)NC(=O)',
+        "AcGM2": '[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)',
+        "AcGM3": '[C@@H](O)[C@H](CO[C@@H]1OC(CO)[C@@H](O[C@@H]2OC(CO)[C@H](O)[C@H](O[C@]3(C(=O)O)CC(O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O3)C2O)[C@H](O)C1O)NC(=O)',
+        "AcGQ1b": '[C@@H](O)[C@H](CO[C@H]1[C@@H]([C@@H](O)[C@H](O[C@@H]2O[C@H](CO)[C@H](O[C@H]3[C@H](NC(=O)C)[C@H]([C@@H](O)[C@H](O3)CO)O[C@@H]3O[C@H](CO)[C@@H]([C@H](O[C@@]4(C[C@H](O)[C@H]([C@@H](O4)[C@@H]([C@@H](CO)O[C@@]4(C[C@H](O)[C@H]([C@@H](O4)[C@H](O)[C@@H](CO)O)NC(C)=O)C(=O)O)O)NC(C)=O)C(O)=O)[C@H]3O)O)[C@H](O[C@]3(O[C@H]([C@@H]([C@@H](O)C3)NC(=O)C)[C@H](O)[C@@H](CO)O[C@@]3(C(=O)O)O[C@@H]([C@@H]([C@@H](CO)O)O)[C@@H]([C@@H](O)C3)NC(=O)C)C(=O)O)[C@H]2O)[C@H](O1)CO)O)NC(=O)',
+        "AcGT1b": '[C@@H](O)[C@H](CO[C@H]1[C@H](O)[C@@H](O)[C@@H]([C@H](O1)CO)O[C@@H]1O[C@H](CO)[C@@H]([C@@H]([C@H]1O)O[C@]1(C(=O)O)C[C@H](O)[C@@H](NC(=O)C)C(O1)[C@H](O)[C@@H](CO)O[C@]1(C(O)=O)C[C@H](O)[C@@H](NC(C)=O)C(O1)[C@H](O)[C@H](O)CO)O[C@H]1[C@H](CC(=O)C)[C@H]([C@@H](O)[C@H](O1)CO)O[C@H]1[C@H](O)[C@@H](O[C@]2(C(O)=O)C[C@H](O)[C@@H](NC(=O)C)C(O2)[C@H](O)[C@H](O)CO)[C@@H](O)[C@@H](CO)O1)NC(=O)',
         "Ceramide": "[C@@H](O)[C@H](CO)NC(=O)",
         "Ceramide_P": "[C@@H](O)[C@H](COP(=O)(O)O)NC(=O)",
         "CPE": "[C@@H](O)[C@H](COP(=O)(O)OCCN)NC(=O)",
-        #"CPI": "C(O)C(COP(O)(=O)OC1C(O)C(O)C(O)C(O)C1O)NC(=O)",
-
+        "GB3": "C(O)C(COC1OC(CO)C(OC2OC(CO)C(OC3OC(CO)C(O)C(O)C3O)C(O)C2O)C(O)C1O)NC(=O)",
         "GcGM2": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(CO)=O)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)", #thand Gemini
         "GcGM3": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(=O)CO)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
         "HexCer": "C(O)C(CO[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O)NC(=O)",
@@ -192,42 +240,50 @@ def get_sphingolipid_smiles(lipidclass, sn_smiles, chains):
         "LysoCPI":  "C(O)C(COP(O)(=O)OC1C(O)C(O)C(O)C(O)C1O)N",
         "LysoHexCer": "[C@H]([C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O)O)O)N)O",
         "LysoLacCer": "[C@H]([C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O[C@H]2[C@@H]([C@H]([C@H]([C@H](O2)CO)O)O)O)O)O)N)O",
-        #"MIP2C": "(O)C(=O)NC(COP(O)(=O)OC1C(O)C(O)C(OC2OC(CO)C(OP(O)(=O)OC3C(O)C(O)C(O)C(O)C3O)C(O)C2O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end
-        #"MIPC": "(O)C(=O)NC(COP(O)(=O)OC1C(O)C(O)C(OC2OC(CO)C(O)C(O)C2O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end
+        "LysoSM": "[C@H]([C@H](COP(=O)([O-])OCC[N+](C)(C)C)N)O",
         "SM": "[C@@H](O)[C@H](COP([O-])(=O)OCC[N+](C)(C)C)NC(=O)",
         "Sulfatide": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@H](O)C(OS(=O)(=O)O)C1O)NC(=O)",
 }
 
-    headgroup_smiles_2OH = { #d lipids, like d18:1
-        "Ceramide": "(O)[C@@H](O)[C@H](CO)NC(=O)",
-        "LCB": "CCCCCCCCCCCCC/C=C/[C@@H](O)[C@H](CO)N",
-        "CPI": "[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)NC(=O)",
-        "MIP2C": "(O)[C@@H](O)[C@H](COP(=O)(O[C@@H]1[C@@H]([C@H](O[C@@H]2O[C@@H]([C@@H](O)[C@@H]([C@@H]2O)O)COP(OC2[C@@H]([C@@H](C(O)[C@@H]([C@H]2O)O)O)O)(=O)O)[C@H]([C@H](O)[C@H]1O)O)O)O)NC(=O)",
-        "MIPC": "(O)C(O)C(COP(O)(OC1C(C(C(OC2C(C(C(O)C(O2)CO)O)O)C(C1O)O)O)O)=O)NC(=O)",
-        "Ceramide_P": "[C@@H](O)[C@H](COP(=O)(O)O)NC(=O)",
+    headgroup_smiles_3OH = { #for t LCBs, like t18:0
+        "Ceramide": "[C@@H](O)[C@@H](O)[C@H](CO)NC(=O)",
+        "LCB": "[C@H]([C@H]([C@H](CO)N)O)O",
+        "LCB_P": "[C@H]([C@H]([C@H](COP(=O)(O)O)N)O)O",
+        "LysoCPE": "C(O)[C@@H](O)[C@H](COP(=O)(O)OCCN)N",
+        "LysoCPI": "C(O)[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)N",
+        "LysoHexCer": "C(O)[C@H]([C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O)O)O)N)O",
+        "CPI": "C(O)[C@@H](O)[C@H](COP(OC1[C@@H]([C@@H](O)C([C@@H](O)[C@H]1O)O)O)(=O)O)NC(=O)",
+        "MIP2C": "[C@@H](O)[C@@H](O)[C@H](COP(O)(=O)O[C@H]1[C@@H]([C@H]([C@H](O)[C@H]([C@H]1O)O[C@H]1[C@H]([C@@H](O)[C@@H]([C@@H](COP(=O)(O)OC2[C@@H]([C@@H](O)C([C@H]([C@H]2O)O)O)O)O1)O)O)O)O)NC(=O)",
+        "MIPC": "C(O)[C@@H](O)[C@H](COP(=O)(O)O[C@@H]1[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H]1O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@@H]1O)NC(=O)",
+        "Ceramide_P": "(O)[C@@H](O)[C@H](COP(O)(O)=O)NC(=O)",
+        "LysoSM": "C(O)[C@H]([C@H](COP(=O)([O-])OCC[N+](C)(C)C)N)O",
+
     }
 
+
 #since LCB hydroxyls are incorporated in the head group portion of the SMILES, we need different headgroups for m,d,t LCBs
-    if chains[1][2] == 0:
+    if chains[0][2] == 0:
         headgroup_smiles = headgroup_smiles_1OH
-    elif chains[1][2] == 1:
+    elif chains[0][2] == 1:
         headgroup_smiles = headgroup_smiles_2OH
-    elif chains[1][2] == 2:
+    elif chains[0][2] == 2:
         headgroup_smiles = headgroup_smiles_3OH
     else:
         return("")
 
-
     if lipidclass not in headgroup_smiles:
         return ""
 
-    #need a means of dealing with hydroxyls here.  2-hydroxy on acyl and (t18:1 and m18:1 species)
+
     sn1_smiles = sn_smiles[0]
-    if (len(sn_smiles) == 2):
-        sn2_smiles = reverse_acyl_smiles(sn_smiles[1])  # reversed because at the other end of the smiles
-        complete_smiles = sn1_smiles[3:] + headgroup_smiles[lipidclass] + sn2_smiles[1:]
+    if (chains[0][2] == 2):
+        complete_smiles = sn1_smiles[4:] + headgroup_smiles[lipidclass]
     else:
         complete_smiles = sn1_smiles[3:] + headgroup_smiles[lipidclass]
+
+    if (len(sn_smiles) == 2):
+        sn2_smiles = reverse_acyl_smiles(sn_smiles[1])  # reversed because at the other end of the smiles
+        complete_smiles += sn2_smiles[1:]
 
     return complete_smiles
 
@@ -238,9 +294,11 @@ def get_glycerolipid_smiles(lipidclass, sn_smiles):
     # They generally go from the first non-carbon atom to the last non-carbon atom, or parenthesis/bracket
     headgroup_smiles = {
         # lipidclass:   #headgroup smiles
-        #phospholipids
+        #glycero and phospholipids
+        "Alkyl_LPA": "[C@](COP(=O)(O)O)([H])(O)CO",
         "Alkyl_LPC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
         "Alkyl_LPE": "OC[C@H](COP(=O)(O)OCCN)O",
+        "Alkyl_LPG": "[C@]([H])(O)(COP(=O)(O)OC[C@@]([H])(O)CO)CO",
         "Alkyl_LPS": "OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
         "Alkyl_PE": "OC[C@H](COP(=O)(O)OCCN)OC(=O)",
         "Alkyl_PC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
@@ -248,14 +306,18 @@ def get_glycerolipid_smiles(lipidclass, sn_smiles):
         "BMP": "(=O)OC[C@@H](O)COP(=O)(O)OC[C@@H](O)COC(=O)",
         "CDP_DG": "(=O)OC[C@H](COP(=O)(O)OP(=O)(O)OC[C@@H]1[C@@H](C([C@@H](O1)N2C=CC(=NC2=O)N)O)O)OC(=O)",
         "DG": "(=O)OC[C@H](CO)OC(=O)",
+        "DGDG": "(=O)OC[C@H](CO[C@@H]1O[C@H](CO[C@H]2O[C@H](CO)[C@H](O)C(O)C2O)[C@H](O)C(O)C1O)OC(=O)",
+        "DGTS": "(=O)OC[C@H](COCCC(C(=O)[O-])[N+](C)(C)C)OC(=O)",
         "DMPE": "(=O)OC[C@H](COP(=O)(O)OCCN(C)C)OC(=O)",
         "FA": "(=O)O",
         "LPA": "(=O)OCC(COP(=O)(O)O)O",
         "LPC": "(=O)OC[C@@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
         "LPE": "(=O)OC[C@H](COP(=O)(O)OCCN)O",
         "LPG": "(=O)OC[C@@H](COP(=O)(O)OC[C@H](CO)O)O",
+        "LPI": "(=O)OC[C@H](COP(=O)(O)OC1[C@@H]([C@H](C([C@H]([C@H]1O)O)O)O)O)O",
         "LPS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
         "MG": "(=O)OCC(CO)O",
+        "MGDG": "(=O)OC[C@H](CO[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O)OC(=O)",
         "MMPE": "(=O)OC[C@H](COP(=O)(O)OCCNC)OC(=O)",
         "PA": "(=O)OCC(COP(=O)(O)O)OC(=O)",
         "PC": "(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
@@ -265,9 +327,10 @@ def get_glycerolipid_smiles(lipidclass, sn_smiles):
         "PS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)",
 
         #the rest
+        "APCS": "(=O)N[C@H](C(=O)O)COP(=O)([O-])OCC[N+](C)(C)C",
         "Carn": "(=O)O[C@H](CC(=O)[O-])C[N+](C)(C)C",
         "CE": "(=O)O[C@H]1CC[C@@]2([C@H]3CC[C@]4([C@H]([C@@H]3CC=C2C1)CC[C@@H]4[C@H](C)CCCC(C)C)C)C",
-        "ErgE": "",
+        "ErgE": "(=O)O[C@H]1CC[C@@]2([C@H]3CC[C@]4([C@H](C3=CC=C2C1)CC[C@@H]4[C@H](C)/C=C/[C@H](C)C(C)C)C)C",
         "Ethanolamine": "(=O)NCCO",
         "FA": "(=O)O",
         "Taurine": "(=O)NCCS(=O)(=O)O",
@@ -275,11 +338,12 @@ def get_glycerolipid_smiles(lipidclass, sn_smiles):
 
     sn2_lyso_headgroup_smiles = {
         # lipidclass:   #headgroup smiles
-
+    "LPA": "(=O)OCC(COP(=O)(O)O)O",
     "LPA": "OCC(COP(=O)(O)O)OC(=O)",
     "LPC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
     "LPE": "OC[C@H](COP(=O)(O)OCCN)OC(=O)",
     "LPG": "OC[C@@H](COP(=O)(O)OC[C@H](CO)O)OC(=O)",
+    "LPI": "OC[C@H](COP(=O)(O)OC1[C@@H]([C@H](C([C@H]([C@H]1O)O)O)O)O)OC(=O)",
     "LPS": "OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)"
     }
 
@@ -311,16 +375,11 @@ def get_glycerolipid_smiles(lipidclass, sn_smiles):
 
 def get_lipid_smiles(lipidclass, backbone, acyl_types, chains):
     sn_smiles = list()
-    #print(backbone + str(acyl_types + chains))
-    if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-        return("")
-    if (c < 6 and h > 0):
-        return("")
+    #print(lipidclass, chains)
     for i in range(0, len(chains)):
         if (chains[i][0] > 5 and chains[i][0] < 22 and chains[i][1] > (chains[i][0] - 5) / 3) or (chains[i][0] < 6 and chains[i][1] > 0):
             return ("")
-        if (chains[i][0] < 6 and chains[i][2] > 0):
-            return ("")
+
 
 
         if acyl_types[i] in ["acyl", "amide", "alkyl"] and chains[i][2] > 1:
@@ -328,8 +387,10 @@ def get_lipid_smiles(lipidclass, backbone, acyl_types, chains):
         if acyl_types[i] in ["acyl", "amide"]:
             new_smiles = (add_dbs(("C" * chains[i][0]), acyl_db_table[chains[i][0]][chains[i][1]], "cis"))
             if chains[i][2] == 1:
-                if i ==0:
-                    sn_smiles.append(add_hydroxyl(new_smiles, 2)) #for now, assuming hydroxyl on acy is at position 2
+               # if (chains[i][0] < 4):
+               #     return ""
+                if (i ==0) :
+                    sn_smiles.append(add_hydroxyl(new_smiles, 2)) #assuming hydroxyl on acyl is at position 2
                 else:
                     sn_smiles.append(add_hydroxyl(new_smiles, 3)) #becasue one c gets chopped later
 
@@ -337,22 +398,19 @@ def get_lipid_smiles(lipidclass, backbone, acyl_types, chains):
                 sn_smiles.append(new_smiles)
         if acyl_types[i] in ["alkyl"]:
             sn_smiles.append(add_dbs(("C" * chains[i][0]), alkyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+
         if acyl_types[i] == "sbase":
             if chains[i][1] < 2: #db < 2
                 sn_smiles.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]], "trans"))
             else:
                 cis_bonds = add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1:], "cis")
                 sn_smiles.append(add_dbs((cis_bonds), sbase_db_table[chains[i][0]][chains[i][1]][0:1], "trans"))
-
     if backbone == "bbSL" and len(chains) < 3:
-        if chains[0][2] == 1: #a normal d base
-            complete_smiles = get_sphingolipid_smiles(lipidclass, sn_smiles)
-        else:
-            return ""
+        complete_smiles = get_sphingolipid_smiles(lipidclass, sn_smiles, chains)
     elif len(chains) < 3:
         complete_smiles = get_glycerolipid_smiles(lipidclass, sn_smiles)
 
-    else:
+    else: #3 or more chains
         match lipidclass:
             case "TG":
                 complete_smiles = get_TG_smiles(lipidclass, sn_smiles)
@@ -364,15 +422,18 @@ def get_lipid_smiles(lipidclass, backbone, acyl_types, chains):
                 complete_smiles = get_HemiBMP_smiles(lipidclass, sn_smiles)
             case "BDP":
                 complete_smiles = get_BDP_smiles(lipidclass, sn_smiles)
+            case "OAcylCeramide":
+               complete_smiles = get_OAcylCeramide_smiles(lipidclass, sn_smiles)
+            case "N_Acyl_PE":
+                 complete_smiles = get_N_Acyl_PE_smiles(lipidclass, sn_smiles)
+            case "N_Acyl_PS":
+                 complete_smiles = get_N_Acyl_PS_smiles(lipidclass, sn_smiles)
             case _:
                 return ""
 
-    #N-acyl_serine, N-acyl_ethanolamine, O-acylceramide all need to figure out smiles.
-    #print("NEW" + complete_smiles)
-    #print("CAN:" + convert_to_canonical_smiles(complete_smiles))
     return convert_to_canonical_smiles(complete_smiles)
 
-
-#my_lipid = get_lipid_smiles("MIPC", "bbSL", ["sbase", "acyl"], [[18,1,1],[16,0,0]])
+#for testing:
+#my_lipid = get_lipid_smiles("OAcylCeramide", "bbAcylSL", ["sbase", "amide", "acyl"], [[14,0,1],[2,0,0],[2,0,0]])
 #print(my_lipid)
 

--- a/calicolipidlibrary/create_smiles.py
+++ b/calicolipidlibrary/create_smiles.py
@@ -1,34 +1,265 @@
+from rdkit import Chem
+import copy
+import numpy as np
 
-
-HEADGROUP_SMILES = {
-    # backbone,   #linkage
-    "PC": "(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
-    "PE": "(=O)OC[C@H](COP(=O)(O)OCCN)OC(=O)"
-}
-
-ACYL_SMILES = {}
-
-for c in range(2,35):
-    for d in range (0,8):
-        for h in range(0,1): #this is just zero for the time being.
-            #add checks to continue of dbs are too high
-            if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-                continue
-            smiles_str = "C" * c
-            match d:
-                case 1:
-                    if c < 13:
-                        smiles_str = smiles_str[0:-8] + "/C=C\\" + smiles_str[-6:]
-                    elif:
-                        smiles_str = smiles_str[0:4] + "/C=C\\" + smiles_str[6:]
-
-
-
-            ACYL_SMILES.update({["acyl", c, d, h]: smiles_str})
-
-# [[type, C, DB, H], "SMILE STRING]
-
-
-
+#this create default positions for dbs.  specifics modified after
+#first dimenstion in number of carbons, second is number of double bonds
+acyl_db_table = {
 
 }
+
+for c in range(10,37):
+    acyl_db_table[c] = {}
+    for d in range(0,7):
+        if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+            continue
+        match d:  # #db
+            case 0:
+                acyl_db_table[c][d] = []
+            case 1:
+                if c < 10:
+                    acyl_db_table[c][d] = [4]
+                else:
+                    acyl_db_table[c][d] = [9]
+            case 2:
+                if c < 14:
+                    acyl_db_table[c][d] = [4,7]
+                else:
+                    acyl_db_table[c][d] = [9 ,12]
+            case 3:
+                acyl_db_table[c][d] = [5, 9 ,12]
+            case 4:
+                acyl_db_table[c][d] = [5,8,11,14]
+            case 5:
+                acyl_db_table[c][d] = [5,8,11,14,17]
+            case 6:
+                acyl_db_table[c][d] = [4,7,10,13,16,19]
+
+
+
+#make sure db placement is in line with most abundant isomer of a specific acyl (overwrites above)
+
+acyl_db_table[20][1] = [11]
+acyl_db_table[22][1] = [13]
+acyl_db_table[24][1] = [15]
+acyl_db_table[20][3] = [8,11,14]
+acyl_db_table[18][4] = [6,9,12,15]
+acyl_db_table[22][4] = [7,10,13,16]
+acyl_db_table[24][5] = [9,12,15,18,21]
+acyl_db_table[24][6] = [6,9,12,15,18,21]
+
+alkyl_db_table = copy.deepcopy(acyl_db_table)
+#modify so first db is always at 1, to make plasmalogens
+#for 2+ db, make plasmalogen, plus location for acyl double bonds for on less db
+for c in range(10,37):
+    for d in range(1,7):
+        if d == 1:
+            alkyl_db_table[c][d] = [1]
+        else:
+            alkyl_db_table[c][d] =[1] + alkyl_db_table[c][d-1]
+
+
+sbase_db_table = copy.deepcopy(acyl_db_table)
+
+#deviations in double bond placement in LCB bases on sphingolipids
+sbase_db_table[16][1] = [1]
+sbase_db_table[17][1] = [1]
+sbase_db_table[18][1] = [1]
+sbase_db_table[19][1] = [1]
+sbase_db_table[20][1] = [1]
+sbase_db_table[18][2] = [1,10]
+#add others as seen in real data
+
+
+#take in any smiles and return canonical smiles
+def convert_to_canonical_SMILES(smiles_str):
+    can_smiles_str = Chem.rdmolfiles.MolToSmiles(Chem.MolFromSmiles(smiles_str))
+    return can_smiles_str
+
+def add_dbs(smile_str, position_list, type): #positions use delta-# notation, so distance from the carboxylic acid
+    smile_str_list = list(smile_str)
+    if len(position_list) == 0:
+        return smile_str
+    for db in position_list:
+        if type == "trans":
+            smile_str_list[-(db+1)] = "/C=C/"
+        elif type == "cis":
+            smile_str_list[-(db+1)] = "/C=C\\"
+        smile_str_list[-db] = ""
+    new_smile_str = ''.join(smile_str_list)
+    return new_smile_str
+
+
+def get_TG_SMILES(lipidclass, sn_SMILES):
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
+    COMPLETE_SMILES = "O=C(OCC(OC(=O)" + sn1_SMILES + ")COC(=O)" + sn2_SMILES + ")" +  sn3_SMILES
+    return COMPLETE_SMILES
+
+def get_CL_SMILES(lipidclass, sn_SMILES):
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
+    sn4_SMILES = sn_SMILES[3][::-1]  # reversed because at the other end of the SMILES
+    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@@H](OC(=O)" + sn2_SMILES + ")COP(=O)(OCC(O)COP(=O)(OC[C@H](OC(=O)" + \
+                        sn3_SMILES + ")COC(=O)" + sn4_SMILES + ")O)O"
+    return COMPLETE_SMILES
+
+
+def get_LysoCL_SMILES(lipidclass, sn_SMILES):
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
+
+    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@H](COP(=O)([O-])OCC(COP(=O)([O-])OC[C@@H](COC(=O)" + \
+                        sn2_SMILES + ")OC(=O)" + sn3_SMILES + ")O)O"
+    return COMPLETE_SMILES
+
+
+def get_BDP_SMILES(lipidclass, sn_SMILES):
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
+    sn4_SMILES = sn_SMILES[3][::-1]  # reversed because at the other end of the SMILES
+    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@@H](COP(=O)(O)OC[C@H](COC(=O)" + sn2_SMILES + ")OC(=O)" + \
+                      sn3_SMILES + ")OC(=O)" + sn4_SMILES
+    return COMPLETE_SMILES
+
+
+def get_HemiBMP_SMILES(lipidclass, sn_SMILES):
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
+    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@H](O)COP(=O)(O)OC[C@@H](COC(=O)" + sn2_SMILES + ")OC(=O)" + \
+                      sn3_SMILES
+    return COMPLETE_SMILES
+
+
+
+def get_sphingolipid_SMILES(lipidclass, sn_SMILES):
+    headgroup_SMILES = {
+        # sphingolipids
+        "AcGM2": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
+        "AcGM3": "[C@@H](O)[C@H](CO[C@@H]1OC(CO)[C@@H](O[C@@H]2OC(CO)[C@H](O)[C@H](O[C@]3(C(=O)O)CC(O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O3)C2O)[C@H](O)C1O)NC(=O)",
+        "Ceramide": "[C@@H](O)[C@H](CO)NC(=O)",
+        "Ceramide_P": "[C@@H](O)[C@H](COP(=O)(O)O)NC(=O)",
+        # GcGM2
+        "GcGM3": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(=O)CO)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
+        "HexCer": "C(O)C(CO[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O)NC(=O)",
+        "SM": "[C@@H](O)[C@H](COP([O-])(=O)OCC[N+](C)(C)C)NC(=O)",
+        "LCB": "[C@@H](O)[C@@H](N)CO",
+        "LCB_P": "[C@H]([C@H](COP(=O)(O)O)N)O",
+        "Sulfatide": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@H](O)C(OS(=O)(=O)O)C1O)NC(=O)",
+}
+
+    if lipidclass not in headgroup_SMILES:
+        return "unknown lipidclass"
+
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    headgroup = headgroup_SMILES[lipidclass]
+
+    COMPLETE_SMILES = sn1_SMILES[3:] + headgroup + sn2_SMILES[1:]
+
+    return COMPLETE_SMILES
+
+#currently does not work for Lysolipids with acyl at SN2 position
+def get_glycerolipid_SMILES(lipidclass, sn_SMILES):
+
+    # Headgroups here are different from that for fragmentation.
+    # They generally go from the first non-carbon atom to the last non-carbon atom, or parenthesis/bracket
+    headgroup_SMILES = {
+        # lipidclass:   #headgroup smiles
+        #phospholipids
+        "Alkyl_LPC": "[C@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
+        "Alkyl_LPE": "[C@H](COP(=O)(O)OCCN)O",
+        "Alkyl_LPS": "[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
+        "Alkyl_PE": "OC[C@H](COP(=O)(O)OCCN)OC(=O)",
+        "Alkyl_PC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
+        "BMP": "(=O)OC[C@@H](O)COP(=O)(O)OC[C@@H](O)COC(=O)",
+        "DG": "(=O)OC[C@H](CO)OC(=O)",
+        "DMPE": "(=O)OC[C@H](COP(=O)(O)OCCN(C)C)OC(=O)",
+        "LPA": "(=O)OCC(COP(=O)(O)O)O",
+        "LPC": "(=O)OC[C@@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
+        "LPE": "(=O)OC[C@H](COP(=O)(O)OCCN)O",
+        "LPG": "(=O)OC[C@@H](COP(=O)([O-])OC[C@H](CO)O)O",
+        "LPS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
+        "MG": "(=O)OCC(CO)O",
+        "MMPE": "(=O)OC[C@H](COP(=O)(O)OCCNC)OC(=O)",
+        "PA": "(=O)OCC(COP(=O)(O)O)OC(=O)",
+        "PC": "(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
+        "PE": "(=O)OC[C@H](COP(=O)(O)OCCN)OC(=O)",
+        "PG": "(=O)OC[C@H](COP(=O)(O)OC[C@H](CO)O)OC(=O)",
+        "PS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)",
+
+        #the rest
+        "Carn": "(=O)O[C@H](CC(=O)[O-])C[N+](C)(C)C",
+        "CE": "(=O)O[C@H]1CC[C@@]2([C@H]3CC[C@]4([C@H]([C@@H]3CC=C2C1)CC[C@@H]4[C@H](C)CCCC(C)C)C)C",
+        "Ethanolamine": "(=O)NCCO",
+        "FA": "(=O)O",
+        "Taurine": "(=O)NCCS(=O)(=O)O",
+    }
+
+    if lipidclass not in headgroup_SMILES:
+        return "unknown lipidclass"
+
+    sn1_SMILES = sn_SMILES[0]
+    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
+    headgroup = headgroup_SMILES[lipidclass]
+    #if lipidclass is a lyso PL and in sn2 position, modify headgroup as needed here
+    # if len(sm_SMILES) == 2 and sn_SMILES[1] == "":
+    # for lyso PL in sn2 position, modify headgroup as needed here
+    COMPLETE_SMILES = sn1_SMILES + headgroup + sn2_SMILES[1:]
+
+    return COMPLETE_SMILES
+
+
+def get_lipid_SMILES(lipidclass, backbone, acyl_types, chains):
+    sn_SMILES = list()
+    #if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+        #ERROR
+
+    for i in range(0, len(chains)):
+        #print("C" * chains[i][0])
+        if acyl_types[i] in ["acyl", "amide"]:
+            sn_SMILES.append(add_dbs(("C" * chains[i][0]), acyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+        if acyl_types[i] in ["alkyl"]:
+            sn_SMILES.append(add_dbs(("C" * chains[i][0]), alkyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+        if acyl_types[i] == "sbase":
+            if chains[i][1] < 2: #db < 2
+                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]], "trans"))
+            else:
+                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1:], "cis"))
+                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1], "trans"))
+
+    if backbone == "bbSL":
+        COMPLETE_SMILES = get_sphingolipid_SMILES(lipidclass, sn_SMILES)
+    elif len(chains) < 3:
+        COMPLETE_SMILES = get_glycerolipid_SMILES(lipidclass, sn_SMILES)
+
+    elif:
+        match lipidclass:
+            case "TG":
+                COMPLETE_SMILES = get_TG_SMILES(lipidclass, sn_SMILES)
+            case "CL":
+                COMPLETE_SMILES = get_CL_SMILES(lipidclass, sn_SMILES)
+            case "LysoCL":
+                COMPLETE_SMILES = get_LysoCL_SMILES(lipidclass, sn_SMILES)
+            case "HemiBMP":
+                COMPLETE_SMILES = get_HemiBMP_SMILES(lipidclass, sn_SMILES)
+            case "BDP":
+                COMPLETE_SMILES = get_BDP_SMILES(lipidclass, sn_SMILES)
+    else:
+        return "Not Available"
+
+    #N-acyl_serine, N-acyl_ethanolamine, O-acylceramide all need to figure out SMILES.
+
+    #print(COMPLETE_SMILES)
+    return convert_to_canonical_SMILES(COMPLETE_SMILES)
+
+
+#my_lipid = get_lipid_SMILES("Ceramide", "bbSL", ["sbase", "acyl"], [[18,1,1],[16,0,0]])
+#print(my_lipid)
+#make test set with pasted SMILES, then compare to the SMILES we get back from running this on the composition.  canonicalize both
+

--- a/calicolipidlibrary/create_smiles.py
+++ b/calicolipidlibrary/create_smiles.py
@@ -1,0 +1,34 @@
+
+
+HEADGROUP_SMILES = {
+    # backbone,   #linkage
+    "PC": "(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
+    "PE": "(=O)OC[C@H](COP(=O)(O)OCCN)OC(=O)"
+}
+
+ACYL_SMILES = {}
+
+for c in range(2,35):
+    for d in range (0,8):
+        for h in range(0,1): #this is just zero for the time being.
+            #add checks to continue of dbs are too high
+            if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                continue
+            smiles_str = "C" * c
+            match d:
+                case 1:
+                    if c < 13:
+                        smiles_str = smiles_str[0:-8] + "/C=C\\" + smiles_str[-6:]
+                    elif:
+                        smiles_str = smiles_str[0:4] + "/C=C\\" + smiles_str[6:]
+
+
+
+            ACYL_SMILES.update({["acyl", c, d, h]: smiles_str})
+
+# [[type, C, DB, H], "SMILE STRING]
+
+
+
+
+}

--- a/calicolipidlibrary/create_smiles.py
+++ b/calicolipidlibrary/create_smiles.py
@@ -1,14 +1,13 @@
 from rdkit import Chem
 import copy
-import numpy as np
 
-#this create default positions for dbs.  specifics modified after
-#first dimenstion in number of carbons, second is number of double bonds
+#this creates default positions for dbs.  specifics modified after
+#first dimension in number of carbons, second is number of double bonds
 acyl_db_table = {
 
 }
 
-for c in range(10,37):
+for c in range(0,37):
     acyl_db_table[c] = {}
     for d in range(0,7):
         if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
@@ -17,7 +16,7 @@ for c in range(10,37):
             case 0:
                 acyl_db_table[c][d] = []
             case 1:
-                if c < 10:
+                if c < 11:
                     acyl_db_table[c][d] = [4]
                 else:
                     acyl_db_table[c][d] = [9]
@@ -35,10 +34,7 @@ for c in range(10,37):
             case 6:
                 acyl_db_table[c][d] = [4,7,10,13,16,19]
 
-
-
 #make sure db placement is in line with most abundant isomer of a specific acyl (overwrites above)
-
 acyl_db_table[20][1] = [11]
 acyl_db_table[22][1] = [13]
 acyl_db_table[24][1] = [15]
@@ -51,28 +47,31 @@ acyl_db_table[24][6] = [6,9,12,15,18,21]
 alkyl_db_table = copy.deepcopy(acyl_db_table)
 #modify so first db is always at 1, to make plasmalogens
 #for 2+ db, make plasmalogen, plus location for acyl double bonds for on less db
-for c in range(10,37):
+for c in range(14,37):
     for d in range(1,7):
+        if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+            continue
         if d == 1:
             alkyl_db_table[c][d] = [1]
-        else:
-            alkyl_db_table[c][d] =[1] + alkyl_db_table[c][d-1]
+        elif d > 1:
+            alkyl_db_table[c][d] =[1] + acyl_db_table[c][d-1]
 
 
 sbase_db_table = copy.deepcopy(acyl_db_table)
+for c in range(14, 37):
+    for d in range(1, 7):
+        if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+            continue
+        if d == 1:
+            sbase_db_table[c][d] = [1]
+        elif d > 1:
+            sbase_db_table[c][d] = [1] + [x - 3 for x in acyl_db_table[c][d-1]]
 
-#deviations in double bond placement in LCB bases on sphingolipids
-sbase_db_table[16][1] = [1]
-sbase_db_table[17][1] = [1]
-sbase_db_table[18][1] = [1]
-sbase_db_table[19][1] = [1]
-sbase_db_table[20][1] = [1]
-sbase_db_table[18][2] = [1,10]
-#add others as seen in real data
 
 
 #take in any smiles and return canonical smiles
-def convert_to_canonical_SMILES(smiles_str):
+def convert_to_canonical_smiles(smiles_str):
+    #print(smiles_str)
     can_smiles_str = Chem.rdmolfiles.MolToSmiles(Chem.MolFromSmiles(smiles_str))
     return can_smiles_str
 
@@ -89,101 +88,136 @@ def add_dbs(smile_str, position_list, type): #positions use delta-# notation, so
     new_smile_str = ''.join(smile_str_list)
     return new_smile_str
 
+def add_hydroxyl(smile_str, position):
+    smile_str_list = list(smile_str)
+    if len(smile_str_list) < position:
+        return smile_str
+    smile_str_list.insert(-(position-1), "(O)")
+    new_smile_str = ''.join(smile_str_list)
+    return new_smile_str
 
-def get_TG_SMILES(lipidclass, sn_SMILES):
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
-    COMPLETE_SMILES = "O=C(OCC(OC(=O)" + sn1_SMILES + ")COC(=O)" + sn2_SMILES + ")" +  sn3_SMILES
-    return COMPLETE_SMILES
+def reverse_acyl_smiles(smiles_str): #allows you to reverse the acyl groups so that they can point the other way, but maintain parentheses correctly
+    new_smiles_str = ""
+    for ch in smiles_str:
+        if ch == "(":
+            new_ch = ")"
+        elif ch == ")":
+            new_ch = "("
+        else:
+            new_ch = ch
 
-def get_CL_SMILES(lipidclass, sn_SMILES):
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
-    sn4_SMILES = sn_SMILES[3][::-1]  # reversed because at the other end of the SMILES
-    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@@H](OC(=O)" + sn2_SMILES + ")COP(=O)(OCC(O)COP(=O)(OC[C@H](OC(=O)" + \
-                        sn3_SMILES + ")COC(=O)" + sn4_SMILES + ")O)O"
-    return COMPLETE_SMILES
-
-
-def get_LysoCL_SMILES(lipidclass, sn_SMILES):
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
-
-    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@H](COP(=O)([O-])OCC(COP(=O)([O-])OC[C@@H](COC(=O)" + \
-                        sn2_SMILES + ")OC(=O)" + sn3_SMILES + ")O)O"
-    return COMPLETE_SMILES
-
-
-def get_BDP_SMILES(lipidclass, sn_SMILES):
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
-    sn4_SMILES = sn_SMILES[3][::-1]  # reversed because at the other end of the SMILES
-    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@@H](COP(=O)(O)OC[C@H](COC(=O)" + sn2_SMILES + ")OC(=O)" + \
-                      sn3_SMILES + ")OC(=O)" + sn4_SMILES
-    return COMPLETE_SMILES
-
-
-def get_HemiBMP_SMILES(lipidclass, sn_SMILES):
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    sn3_SMILES = sn_SMILES[2][::-1]  # reversed because at the other end of the SMILES
-    COMPLETE_SMILES = sn1_SMILES + "(=O)OC[C@H](O)COP(=O)(O)OC[C@@H](COC(=O)" + sn2_SMILES + ")OC(=O)" + \
-                      sn3_SMILES
-    return COMPLETE_SMILES
+        new_smiles_str = new_ch + new_smiles_str
+    return new_smiles_str
 
 
 
-def get_sphingolipid_SMILES(lipidclass, sn_SMILES):
-    headgroup_SMILES = {
+def get_TG_smiles(lipidclass, sn_smiles):
+    sn1_smiles = reverse_acyl_smiles(sn_smiles[0])[1:]
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])[1:]  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[1:]  # reversed because at the other end of the smiles
+    complete_smiles = "O=C(OCC(OC(=O)" + sn1_smiles + ")COC(=O)" + sn2_smiles + ")" +  sn3_smiles
+    return complete_smiles
+
+def get_CL_smiles(lipidclass, sn_smiles):
+    sn1_smiles = sn_smiles[0]
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])[1:]  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[1:]  # reversed because at the other end of the smiles
+    sn4_smiles = reverse_acyl_smiles(sn_smiles[3])[1:]  # reversed because at the other end of the smiles
+    complete_smiles = sn1_smiles + "(=O)OC[C@@H](OC(=O)" + sn2_smiles + ")COP(=O)(OCC(O)COP(=O)(OC[C@H](OC(=O)" + \
+                        sn3_smiles + ")COC(=O)" + sn4_smiles + ")O)O"
+    return complete_smiles
+
+
+def get_LysoCL_smiles(lipidclass, sn_smiles):
+    sn1_smiles = sn_smiles[0]
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])[1:]  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[1:]  # reversed because at the other end of the smiles
+
+    complete_smiles = sn1_smiles + "(=O)OC[C@H](COP(=O)(O)OCC(COP(=O)(O)OC[C@@H](COC(=O)" + \
+                        sn2_smiles + ")OC(=O)" + sn3_smiles + ")O)O"
+    return complete_smiles
+
+
+def get_BDP_smiles(lipidclass, sn_smiles):
+    sn1_smiles = sn_smiles[0]
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])[1:]  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[1:]  # reversed because at the other end of the smiles
+    sn4_smiles = reverse_acyl_smiles(sn_smiles[3])[1:]  # reversed because at the other end of the smiles
+    complete_smiles = sn1_smiles + "(=O)OC[C@@H](COP(=O)(O)OC[C@H](COC(=O)" + sn2_smiles + ")OC(=O)" + \
+                      sn3_smiles + ")OC(=O)" + sn4_smiles
+    return complete_smiles
+
+
+def get_HemiBMP_smiles(lipidclass, sn_smiles):
+    sn1_smiles = sn_smiles[0]
+    sn2_smiles = reverse_acyl_smiles(sn_smiles[1])[1:]  # reversed because at the other end of the smiles
+    sn3_smiles = reverse_acyl_smiles(sn_smiles[2])[1:]  # reversed because at the other end of the smiles
+    complete_smiles = sn1_smiles + "(=O)OC[C@H](O)COP(=O)(O)OC[C@@H](COC(=O)" + sn2_smiles + ")OC(=O)" + \
+                      sn3_smiles
+    return complete_smiles
+
+
+
+def get_sphingolipid_smiles(lipidclass, sn_smiles):
+    headgroup_smiles = {
         # sphingolipids
         "AcGM2": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O[C@@H]3O[C@H](CO)[C@H](O)[C@H](O)[C@H]3NC(C)=O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(C)=O)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
         "AcGM3": "[C@@H](O)[C@H](CO[C@@H]1OC(CO)[C@@H](O[C@@H]2OC(CO)[C@H](O)[C@H](O[C@]3(C(=O)O)CC(O)[C@@H](NC(C)=O)C([C@H](O)[C@H](O)CO)O3)C2O)[C@H](O)C1O)NC(=O)",
         "Ceramide": "[C@@H](O)[C@H](CO)NC(=O)",
         "Ceramide_P": "[C@@H](O)[C@H](COP(=O)(O)O)NC(=O)",
-        # GcGM2
+        "CPE": "[C@@H](O)[C@H](COP(=O)(O)OCCN)NC(=O)",
+        #"CPI": "C(=O)NC(COP(O)(=O)OC1C(O)C(O)C(O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end.  I think fixed below
+        "CPI": "C(O)C(COP(O)(=O)OC1C(O)C(O)C(O)C(O)C1O)NC(=O)",
+        # "GcGM2":
         "GcGM3": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O[C@]3(C(=O)O)C[C@H](O)[C@@H](NC(=O)CO)[C@H]([C@H](O)[C@H](O)CO)O3)[C@H]2O)[C@H](O)[C@H]1O)NC(=O)",
         "HexCer": "C(O)C(CO[C@@H]1O[C@H](CO)[C@H](O)[C@H](O)[C@H]1O)NC(=O)",
-        "SM": "[C@@H](O)[C@H](COP([O-])(=O)OCC[N+](C)(C)C)NC(=O)",
         "LCB": "[C@@H](O)[C@@H](N)CO",
         "LCB_P": "[C@H]([C@H](COP(=O)(O)O)N)O",
+        "LysoCPE": "[C@@H](O)[C@H](COP(=O)(O)OCCN)N",
+        #"LysoCPI": "NC(COP(O)(=O)OC1C(O)C(O)C(O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end
+        "LysoHexCer": "[C@H]([C@H](CO[C@H]1[C@@H]([C@H]([C@@H]([C@H](O1)CO)O)O)O)N)O",
+        #"MIP2C": "(O)C(=O)NC(COP(O)(=O)OC1C(O)C(O)C(OC2OC(CO)C(OP(O)(=O)OC3C(O)C(O)C(O)C(O)C3O)C(O)C2O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end
+        #"MIPC": "(O)C(=O)NC(COP(O)(=O)OC1C(O)C(O)C(OC2OC(CO)C(O)C(O)C2O)C(O)C1O)C(O)C(O)", #this is backwards, N needs to be at the end
+        "SM": "[C@@H](O)[C@H](COP([O-])(=O)OCC[N+](C)(C)C)NC(=O)",
         "Sulfatide": "[C@@H](O)[C@H](CO[C@@H]1O[C@H](CO)[C@H](O)C(OS(=O)(=O)O)C1O)NC(=O)",
 }
 
-    if lipidclass not in headgroup_SMILES:
-        return "unknown lipidclass"
+    if lipidclass not in headgroup_smiles:
+        return ""
 
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    headgroup = headgroup_SMILES[lipidclass]
+    #need a means of dealing with hydroxyls here.  2-hydroxy on acyl and (t18:1 and m18:1 species)
+    sn1_smiles = sn_smiles[0]
+    if (len(sn_smiles) == 2):
+        sn2_smiles = reverse_acyl_smiles(sn_smiles[1])  # reversed because at the other end of the smiles
+        complete_smiles = sn1_smiles[3:] + headgroup_smiles[lipidclass] + sn2_smiles[1:]
+    else:
+        complete_smiles = sn1_smiles[3:] + headgroup_smiles[lipidclass]
 
-    COMPLETE_SMILES = sn1_SMILES[3:] + headgroup + sn2_SMILES[1:]
-
-    return COMPLETE_SMILES
+    return complete_smiles
 
 #currently does not work for Lysolipids with acyl at SN2 position
-def get_glycerolipid_SMILES(lipidclass, sn_SMILES):
+def get_glycerolipid_smiles(lipidclass, sn_smiles):
 
     # Headgroups here are different from that for fragmentation.
     # They generally go from the first non-carbon atom to the last non-carbon atom, or parenthesis/bracket
-    headgroup_SMILES = {
+    headgroup_smiles = {
         # lipidclass:   #headgroup smiles
         #phospholipids
-        "Alkyl_LPC": "[C@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
-        "Alkyl_LPE": "[C@H](COP(=O)(O)OCCN)O",
-        "Alkyl_LPS": "[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
+        "Alkyl_LPC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
+        "Alkyl_LPE": "OC[C@H](COP(=O)(O)OCCN)O",
+        "Alkyl_LPS": "OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
         "Alkyl_PE": "OC[C@H](COP(=O)(O)OCCN)OC(=O)",
         "Alkyl_PC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
+        "Alkyl_PS": "OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)",
         "BMP": "(=O)OC[C@@H](O)COP(=O)(O)OC[C@@H](O)COC(=O)",
+        "CDP_DG": "(=O)OC[C@H](COP(=O)(O)OP(=O)(O)OC[C@@H]1[C@@H](C([C@@H](O1)N2C=CC(=NC2=O)N)O)O)OC(=O)",
         "DG": "(=O)OC[C@H](CO)OC(=O)",
         "DMPE": "(=O)OC[C@H](COP(=O)(O)OCCN(C)C)OC(=O)",
+        "FA": "(=O)O",
         "LPA": "(=O)OCC(COP(=O)(O)O)O",
         "LPC": "(=O)OC[C@@H](COP(=O)([O-])OCC[N+](C)(C)C)O",
         "LPE": "(=O)OC[C@H](COP(=O)(O)OCCN)O",
-        "LPG": "(=O)OC[C@@H](COP(=O)([O-])OC[C@H](CO)O)O",
+        "LPG": "(=O)OC[C@@H](COP(=O)(O)OC[C@H](CO)O)O",
         "LPS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)O",
         "MG": "(=O)OCC(CO)O",
         "MMPE": "(=O)OC[C@H](COP(=O)(O)OCCNC)OC(=O)",
@@ -191,6 +225,7 @@ def get_glycerolipid_SMILES(lipidclass, sn_SMILES):
         "PC": "(=O)OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
         "PE": "(=O)OC[C@H](COP(=O)(O)OCCN)OC(=O)",
         "PG": "(=O)OC[C@H](COP(=O)(O)OC[C@H](CO)O)OC(=O)",
+        "PI": "(=O)OC[C@H](COP(=O)(O)OC1[C@@H]([C@H](C([C@H]([C@H]1O)O)O)O)O)OC(=O)",
         "PS": "(=O)OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)",
 
         #the rest
@@ -201,65 +236,106 @@ def get_glycerolipid_SMILES(lipidclass, sn_SMILES):
         "Taurine": "(=O)NCCS(=O)(=O)O",
     }
 
-    if lipidclass not in headgroup_SMILES:
-        return "unknown lipidclass"
+    sn2_lyso_headgroup_smiles = {
+        # lipidclass:   #headgroup smiles
 
-    sn1_SMILES = sn_SMILES[0]
-    sn2_SMILES = sn_SMILES[1][::-1]  # reversed because at the other end of the SMILES
-    headgroup = headgroup_SMILES[lipidclass]
-    #if lipidclass is a lyso PL and in sn2 position, modify headgroup as needed here
-    # if len(sm_SMILES) == 2 and sn_SMILES[1] == "":
+    "LPA": "OCC(COP(=O)(O)O)OC(=O)",
+    "LPC": "OC[C@H](COP(=O)([O-])OCC[N+](C)(C)C)OC(=O)",
+    "LPE": "OC[C@H](COP(=O)(O)OCCN)OC(=O)",
+    "LPG": "OC[C@@H](COP(=O)(O)OC[C@H](CO)O)OC(=O)",
+    "LPS": "OC[C@H](COP(=O)(O)OC[C@@H](C(=O)O)N)OC(=O)"
+    }
+
+    if lipidclass not in headgroup_smiles:
+        return ""
+
+    # if lipidclass is a lyso PL and in sn2 position,
+    if(len(sn_smiles) == 2 and sn_smiles[0] == ""):
+        headgroup = sn2_lyso_headgroup_smiles[lipidclass]
+    else: # all others
+        headgroup = headgroup_smiles[lipidclass]
+
+    sn1_smiles = sn_smiles[0]
+    if (len(sn_smiles) > 1):
+        sn2_smiles = sn_smiles[1][::-1]  # reversed because at the other end of the smiles
+        complete_smiles = sn1_smiles + headgroup + sn2_smiles[1:]
+    else:
+        complete_smiles = sn1_smiles + headgroup
+
+
+
+
+
+    # if len(sm_smiles) == 2 and sn_smiles[1] == "":
     # for lyso PL in sn2 position, modify headgroup as needed here
-    COMPLETE_SMILES = sn1_SMILES + headgroup + sn2_SMILES[1:]
 
-    return COMPLETE_SMILES
+    return complete_smiles
 
 
-def get_lipid_SMILES(lipidclass, backbone, acyl_types, chains):
-    sn_SMILES = list()
-    #if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-        #ERROR
-
+def get_lipid_smiles(lipidclass, backbone, acyl_types, chains):
+    sn_smiles = list()
+    #print(backbone + str(acyl_types + chains))
+    if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+        return("")
+    if (c < 6 and h > 0):
+        return("")
     for i in range(0, len(chains)):
-        #print("C" * chains[i][0])
+        if (chains[i][0] > 5 and chains[i][0] < 22 and chains[i][1] > (chains[i][0] - 5) / 3) or (chains[i][0] < 6 and chains[i][1] > 0):
+            return ("")
+        if (chains[i][0] < 6 and chains[i][2] > 0):
+            return ("")
+
+
+        if acyl_types[i] in ["acyl", "amide", "alkyl"] and chains[i][2] > 1:
+            return ""
         if acyl_types[i] in ["acyl", "amide"]:
-            sn_SMILES.append(add_dbs(("C" * chains[i][0]), acyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+            new_smiles = (add_dbs(("C" * chains[i][0]), acyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+            if chains[i][2] == 1:
+                if i ==0:
+                    sn_smiles.append(add_hydroxyl(new_smiles, 2)) #for now, assuming hydroxyl on acy is at position 2
+                else:
+                    sn_smiles.append(add_hydroxyl(new_smiles, 3)) #becasue one c gets chopped later
+
+            else:
+                sn_smiles.append(new_smiles)
         if acyl_types[i] in ["alkyl"]:
-            sn_SMILES.append(add_dbs(("C" * chains[i][0]), alkyl_db_table[chains[i][0]][chains[i][1]], "cis"))
+            sn_smiles.append(add_dbs(("C" * chains[i][0]), alkyl_db_table[chains[i][0]][chains[i][1]], "cis"))
         if acyl_types[i] == "sbase":
             if chains[i][1] < 2: #db < 2
-                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]], "trans"))
+                sn_smiles.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]], "trans"))
             else:
-                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1:], "cis"))
-                sn_SMILES.append(add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1], "trans"))
+                cis_bonds = add_dbs(("C" * chains[i][0]), sbase_db_table[chains[i][0]][chains[i][1]][1:], "cis")
+                sn_smiles.append(add_dbs((cis_bonds), sbase_db_table[chains[i][0]][chains[i][1]][0:1], "trans"))
 
-    if backbone == "bbSL":
-        COMPLETE_SMILES = get_sphingolipid_SMILES(lipidclass, sn_SMILES)
+    if backbone == "bbSL" and len(chains) < 3:
+        if chains[0][2] == 1: #a normal d base
+            complete_smiles = get_sphingolipid_smiles(lipidclass, sn_smiles)
+        else:
+            return ""
     elif len(chains) < 3:
-        COMPLETE_SMILES = get_glycerolipid_SMILES(lipidclass, sn_SMILES)
+        complete_smiles = get_glycerolipid_smiles(lipidclass, sn_smiles)
 
-    elif:
+    else:
         match lipidclass:
             case "TG":
-                COMPLETE_SMILES = get_TG_SMILES(lipidclass, sn_SMILES)
+                complete_smiles = get_TG_smiles(lipidclass, sn_smiles)
             case "CL":
-                COMPLETE_SMILES = get_CL_SMILES(lipidclass, sn_SMILES)
+                complete_smiles = get_CL_smiles(lipidclass, sn_smiles)
             case "LysoCL":
-                COMPLETE_SMILES = get_LysoCL_SMILES(lipidclass, sn_SMILES)
+                complete_smiles = get_LysoCL_smiles(lipidclass, sn_smiles)
             case "HemiBMP":
-                COMPLETE_SMILES = get_HemiBMP_SMILES(lipidclass, sn_SMILES)
+                complete_smiles = get_HemiBMP_smiles(lipidclass, sn_smiles)
             case "BDP":
-                COMPLETE_SMILES = get_BDP_SMILES(lipidclass, sn_SMILES)
-    else:
-        return "Not Available"
+                complete_smiles = get_BDP_smiles(lipidclass, sn_smiles)
+            case _:
+                return ""
 
-    #N-acyl_serine, N-acyl_ethanolamine, O-acylceramide all need to figure out SMILES.
+    #N-acyl_serine, N-acyl_ethanolamine, O-acylceramide all need to figure out smiles.
+    #print("NEW" + complete_smiles)
+    #print("CAN:" + convert_to_canonical_smiles(complete_smiles))
+    return convert_to_canonical_smiles(complete_smiles)
 
-    #print(COMPLETE_SMILES)
-    return convert_to_canonical_SMILES(COMPLETE_SMILES)
 
-
-#my_lipid = get_lipid_SMILES("Ceramide", "bbSL", ["sbase", "acyl"], [[18,1,1],[16,0,0]])
+#my_lipid = get_lipid_smiles("MIPC", "bbSL", ["sbase", "acyl"], [[18,1,1],[16,0,0]])
 #print(my_lipid)
-#make test set with pasted SMILES, then compare to the SMILES we get back from running this on the composition.  canonicalize both
 

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -440,7 +440,7 @@ class Lipid:
         self.adduct = ""
         self.lipidName = ""
 
-    # for standards C30 method
+    # for standard C30 method
     # neg_adduct_set = ["[M-H]-", "[M+FA-H]-", "[M+Cl]-"]
     # pos_adduct_set = ["[M+H]+", "[M+Na]+", "[M+K]+", "[M+NH4]+"]
     # NCE = "20,30,40"
@@ -742,12 +742,10 @@ class Lipid:
         smiles_mw = Chem.Descriptors.ExactMolWt(mol)
         if smiles != "" and smiles_mw != 0.0  and (abs(MASS - smiles_mw) > .0001):
             if(len(self.chains) ==1 or self.chains[1][2] == 0):
-
                 print(FullName)
-                print("SMILES MW: " + str(Chem.Descriptors.ExactMolWt(mol)))
-                print("My MW: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)))
+                print("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)))
 
-        RECORD.append("SMILES CF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)) + "\n")
+        RECORD.append("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)) + "\n")
         #end of temporary check
 
         for f in FRAGMENTS:

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -733,8 +733,10 @@ class Lipid:
         RECORD.append("SMILES: " + get_lipid_smiles(self.lipidclass, LIPID_BACKBONES[self.lipidclass][0],
                                                     LIPID_BACKBONES[self.lipidclass][1], self.chains) + "\n")
         RECORD.append("NumPeaks: " + str(len(FRAGMENTS)) + "\n")
-        smiles = get_lipid_smiles(self.lipidclass, LIPID_BACKBONES[self.lipidclass][0],
-                                                     LIPID_BACKBONES[self.lipidclass][1], self.chains)
+
+
+        # smiles = get_lipid_smiles(self.lipidclass, LIPID_BACKBONES[self.lipidclass][0],
+        #                                              LIPID_BACKBONES[self.lipidclass][1], self.chains)
 
         # Temporary checks to make sure that molecular weight from smiles matches that calculated from headgroup+sn
         # mol = Chem.MolFromSmiles(smiles)
@@ -743,7 +745,7 @@ class Lipid:
         #     print(FullName)
         #     print("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)))
 
-        RECORD.append("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)) + "\n")
+        #RECORD.append("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)) + "\n")
         #end of temporary check
 
         for f in FRAGMENTS:
@@ -791,7 +793,7 @@ class Lipid:
             handle.close()
 
 
-# DG, PA, PC, PE, PG, PI, PS, BMP, HexDG, MMPE, DMPE, DG, FAFHFA
+# DG, PA, PC, PE, PG, PI, PS, BMP, HexDG, MMPE, DMPE, DG, FAFHA
 class GPL(Lipid):
     chain1_ranges = []
     for c in [2] + list(range(10, 22)) + list(range(22, 34, 2)):
@@ -807,7 +809,7 @@ class GPL(Lipid):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
             h = 0
-            chain1_ranges.append([c, d, h])
+            chain2_ranges.append([c, d, h])
 
     chain_sets = []
     for c1 in chain1_ranges:
@@ -815,7 +817,6 @@ class GPL(Lipid):
             # if c2[0] < c1[0]: continue
             # if (c2[0] == c1[0] and c2[1] < c1[0]): continue
             chain_sets.append([c1, c2])
-
 
 # Alkyl_PC, Alkyl_PE, Alkyl_PS
 class alkylGPL(Lipid):
@@ -833,7 +834,7 @@ class alkylGPL(Lipid):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
             h = 0
-            chain1_ranges.append([c, d, h])
+            chain2_ranges.append([c, d, h])
 
     chain_sets = []
     for c1 in chain1_ranges:
@@ -899,6 +900,8 @@ class NAcylGPL(Lipid):
 # AcGM2, AcGM3, GcGM2, GcGM3, MIP2C, MIPC, HexCer, LacCer, PI_Cer, Sulfatide, SM, Ceramide_P
 #Ceramides are separate, as we need to make deoxyceramides, but not other sphingolipids
 # Note that for Sphingolipids, the hydroxyl "head group" does not count as a hydroxyl for the purposes of this script
+#LCB and Ceramide chains are defined in LCB.py and Ceramide.py
+
 
 class SphingoLipid(Lipid):
 
@@ -925,30 +928,6 @@ class SphingoLipid(Lipid):
         for c2 in chain2_ranges:
             chain_sets.append([c1, c2])
 
-class Ceramide(Lipid):
-
-    chain1_ranges = []
-    for c in range(14, 23):
-        for d in range(0, 2):
-            for h in range(1, 3):
-                if (h > 1 and d > 0):
-                    continue
-                chain1_ranges.append([c, d, h])
-
-    chain2_ranges = []
-    for c in [2] + list(range(14, 25)):
-        for d in range(0, 7):
-            for h in range(0, 2):
-                if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-                    continue
-                if (h > 0 and c == 2):
-                    continue
-                chain2_ranges.append([c, d, h])
-
-    chain_sets = []
-    for c1 in chain1_ranges:
-        for c2 in chain2_ranges:
-            chain_sets.append([c1, c2])
 
 
 class PhytoSphingoLipid(Lipid):
@@ -1073,18 +1052,6 @@ class LysoSphingoLipid(Lipid):
     for c1 in chain1_ranges:
         chain_sets.append([c1])
 
-
-class LCB(Lipid):
-    chain1_ranges = []
-    for c in range(14, 23):
-        for d in range(0, 3):
-            for h in range(0, 3):
-                if (h == 2 and d > 0):
-                    continue
-                chain1_ranges.append([c, d, h])
-    chain_sets = []
-    for c1 in chain1_ranges:
-        chain_sets.append([c1])
 
 
 

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -324,9 +324,9 @@ LIPID_HEADS = {
     "AcGM1": [23 + 8 + 6, 38 + 15 - 2 + 10, 1 + 1, 19 + 6 + 5 - 1, 0, 0],
     "AcGD2": [48 - 6, 78 - 10, 3, 37 - 5, 0, 0],
     "AcGD3": [48 - 6 - 8, 78 - 10 - 13, 3 - 1, 37 - 5 - 5, 0, 0],
-    "AcGD1a": [48, 78, 3, 37, 0, 0],
-    "AcGD1b": [48, 78, 3, 37, 0, 0],
-    "AcGT1b": [48 + 11, 78 + 17, 3 + 1, 37 + 8, 0, 0],
+    "AcGD1a": [49, 79, 2, 37, 0, 0],
+    "AcGD1b": [49, 79, 2, 37, 0, 0],
+    "AcGT1b": [60, 96, 3, 45, 0, 0],
     "AcGQ1b": [48 + 22, 78 + 34, 3 + 2, 37 + 16, 0, 0],
     "GcGM3": [23, 38, 1, 20, 0, 0],
     "GcGM2": [23 + 8, 38 + 15 - 2, 1 + 1, 20 + 6 - 1, 0, 0],
@@ -450,7 +450,7 @@ class Lipid:
     #pos_adduct_set = ["[M+Li]+", "[M+H]+", "[M+Na]+", "[M+NH4]+", "[M+K]+"]
     neg_adduct_set = ["[M-H]-","[M+FA-H]-"]
     pos_adduct_set = ["[M+H]+", "[M+Na]+", "[M+NH4]+"]
-    NCE = ""
+    NCE =  "20,30,40"
 
     # lipidclass is one of the above listed lipid backbones
     # chains is a list of lists, where each member list is [#carbons, #double bond, #hydroxyls] for one carbon chain in the lipid
@@ -733,17 +733,15 @@ class Lipid:
         RECORD.append("SMILES: " + get_lipid_smiles(self.lipidclass, LIPID_BACKBONES[self.lipidclass][0],
                                                     LIPID_BACKBONES[self.lipidclass][1], self.chains) + "\n")
         RECORD.append("NumPeaks: " + str(len(FRAGMENTS)) + "\n")
-
         smiles = get_lipid_smiles(self.lipidclass, LIPID_BACKBONES[self.lipidclass][0],
                                                      LIPID_BACKBONES[self.lipidclass][1], self.chains)
 
-        #Temporary checks to make sure that WM from smiles matches the calculated MW
-        mol = Chem.MolFromSmiles(smiles)
-        smiles_mw = Chem.Descriptors.ExactMolWt(mol)
-        if smiles != "" and smiles_mw != 0.0  and (abs(MASS - smiles_mw) > .0001):
-            if(len(self.chains) ==1 or self.chains[1][2] == 0):
-                print(FullName)
-                print("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)))
+        # Temporary checks to make sure that molecular weight from smiles matches that calculated from headgroup+sn
+        # mol = Chem.MolFromSmiles(smiles)
+        # smiles_mw = Chem.Descriptors.ExactMolWt(mol)
+        # if smiles == "" or smiles_mw == 0.0  or (abs(MASS - smiles_mw) > .0001):
+        #     print(FullName)
+        #     print("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)))
 
         RECORD.append("SMILES MF: " + str(Chem.rdMolDescriptors.CalcMolFormula(mol)) + "\n")
         #end of temporary check
@@ -800,16 +798,16 @@ class GPL(Lipid):
         for d in range(0, 7):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
-            for h in [0]:
-                chain1_ranges.append([c, d, h])
+            h = 0
+            chain1_ranges.append([c, d, h])
 
     chain2_ranges = []
     for c in [2] + list(range(10, 22)) + list(range(22, 34, 2)):
         for d in range(0, 7):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
-            for h in [0]:
-                chain2_ranges.append([c, d, h])
+            h = 0
+            chain1_ranges.append([c, d, h])
 
     chain_sets = []
     for c1 in chain1_ranges:
@@ -826,16 +824,16 @@ class alkylGPL(Lipid):
         for d in range(0, 3):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
-            for h in [0]:
-                chain1_ranges.append([c, d, h])
+            h = 0
+            chain1_ranges.append([c, d, h])
 
     chain2_ranges = []
     for c in [2] + list(range(10, 22)) + list(range(22, 34, 2)):
         for d in range(0, 7):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
-            for h in [0]:
-                chain2_ranges.append([c, d, h])
+            h = 0
+            chain1_ranges.append([c, d, h])
 
     chain_sets = []
     for c1 in chain1_ranges:
@@ -850,8 +848,8 @@ class Triglyceride(Lipid):
         for d in range(0, 7):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
-            for h in [0]:
-                chain1_ranges.append([c, d, h])
+            h = 0
+            chain1_ranges.append([c, d, h])
 
     chain2_ranges = chain1_ranges
     chain3_ranges = chain1_ranges
@@ -877,13 +875,7 @@ class NAcylGPL(Lipid):
             for h in [0]:
                 chain1_ranges.append([c, d, h])
 
-    chain2_ranges = []
-    for c in [2] + list(range(10, 26, 2)):
-        for d in range(0, 7):
-            if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-                continue
-            for h in [0]:
-                chain2_ranges.append([c, d, h])
+    chain2_ranges = chain1_ranges
 
     chain3_ranges = []
     for c in [2] + list(range(10, 26, 2)):
@@ -899,21 +891,23 @@ class NAcylGPL(Lipid):
             for c3 in chain3_ranges:
                 if c2[0] < c1[0]:
                     continue
-                if c2[0] == c1[0] and c2[1] < c1[0]:
-                    continue
+#                if ((c2[0] == c1[0]) and (c2[1] < c1[0])):
+#                    continue
                 chain_sets.append([c1, c2, c3])
 
 
-# AcGM2, AcGM3, GcGM2, GcGM3, MIP2C, MIPC, HexCer, LacCer, PI_Cer, Sulfatide, SM, Ceramide, Ceramide_P
+# AcGM2, AcGM3, GcGM2, GcGM3, MIP2C, MIPC, HexCer, LacCer, PI_Cer, Sulfatide, SM, Ceramide_P
+#Ceramides are separate, as we need to make deoxyceramides, but not other sphingolipids
 # Note that for Sphingolipids, the hydroxyl "head group" does not count as a hydroxyl for the purposes of this script
-
 
 class SphingoLipid(Lipid):
 
     chain1_ranges = []
     for c in range(14, 23):
         for d in range(0, 2):
-            for h in range(0, 3):
+            for h in range(1, 2):
+                if (h > 1 and d > 0):
+                    continue
                 chain1_ranges.append([c, d, h])
 
     chain2_ranges = []
@@ -921,6 +915,33 @@ class SphingoLipid(Lipid):
         for d in range(0, 7):
             for h in range(0, 2):
                 if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                        continue
+                if (h > 0 and c == 2):
+                    continue
+                chain2_ranges.append([c, d, h])
+
+    chain_sets = []
+    for c1 in chain1_ranges:
+        for c2 in chain2_ranges:
+            chain_sets.append([c1, c2])
+
+class Ceramide(Lipid):
+
+    chain1_ranges = []
+    for c in range(14, 23):
+        for d in range(0, 2):
+            for h in range(1, 3):
+                if (h > 1 and d > 0):
+                    continue
+                chain1_ranges.append([c, d, h])
+
+    chain2_ranges = []
+    for c in [2] + list(range(14, 25)):
+        for d in range(0, 7):
+            for h in range(0, 2):
+                if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                    continue
+                if (h > 0 and c == 2):
                     continue
                 chain2_ranges.append([c, d, h])
 
@@ -930,12 +951,41 @@ class SphingoLipid(Lipid):
             chain_sets.append([c1, c2])
 
 
+class PhytoSphingoLipid(Lipid):
+
+    chain1_ranges = []
+    for c in range(14, 23):
+        d = 0
+        h = 2
+        chain1_ranges.append([c, d, h])
+
+    chain2_ranges = []
+    for c in [2] + list(range(14, 31)):
+        for d in range(0, 7):
+            for h in range(0, 2):
+                if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                    continue
+                if (h > 0 and c == 2):
+                    continue
+                chain2_ranges.append([c, d, h])
+
+    chain_sets = []
+    for c1 in chain1_ranges:
+        for c2 in chain2_ranges:
+            chain_sets.append([c1, c2])
+
+
+
+
+#O-acyl-ceramides
 class AcylSphingoLipid(Lipid):
     chain1_ranges = []
     for c in range(14, 21):
         for d in range(0, 2):
             for h in range(1, 2):
                 if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                    continue
+                if (h > 1 and d > 0):
                     continue
                 chain1_ranges.append([c, d, h])
 
@@ -945,15 +995,17 @@ class AcylSphingoLipid(Lipid):
             for h in range(0, 2):
                 if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                     continue
+                if (h > 0 and c == 2):
+                    continue
                 chain2_ranges.append([c, d, h])
 
     chain3_ranges = []
     for c in [2] + list(range(14, 25)):
         for d in range(0, 7):
-            for h in range(0, 2):
-                if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
-                    continue
-                chain3_ranges.append([c, d, h])
+            h = 0
+            if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
+                continue
+            chain3_ranges.append([c, d, h])
 
     chain_sets = []
     for c1 in chain1_ranges:
@@ -1007,17 +1059,34 @@ class AlkylLysoGPL(Lipid):
         chain_sets.append([c1])
 
 
-# LysoHexCer, LysoSM, LCB
+# LysoHexCer, LysoSM,
 # Note that for Sphingolipids, the hydroxyl "head group" does not count as a hydroxyl for the purposes of this script
 class LysoSphingoLipid(Lipid):
     chain1_ranges = []
     for c in range(14, 23):
         for d in range(0, 3):
-            for h in range(0, 3):
+            for h in range(1, 3):
+                if (h == 2 and d > 0):
+                    continue
                 chain1_ranges.append([c, d, h])
     chain_sets = []
     for c1 in chain1_ranges:
         chain_sets.append([c1])
+
+
+class LCB(Lipid):
+    chain1_ranges = []
+    for c in range(14, 23):
+        for d in range(0, 3):
+            for h in range(0, 3):
+                if (h == 2 and d > 0):
+                    continue
+                chain1_ranges.append([c, d, h])
+    chain_sets = []
+    for c1 in chain1_ranges:
+        chain_sets.append([c1])
+
+
 
 
 # CE, ErgE, Ethanolamine, FA, Carn,
@@ -1028,6 +1097,8 @@ class singleAcyl(Lipid):
             if (c > 5 and c < 22 and d > (c - 5) / 3) or (c < 6 and d > 0):
                 continue
             for h in [0, 1]:
+                if (h > 0 and c < 6):
+                    continue
                 chain1_ranges.append([c, d, h])
     chain_sets = []
     for c1 in chain1_ranges:

--- a/calicolipidlibrary/lipidRules.py
+++ b/calicolipidlibrary/lipidRules.py
@@ -132,8 +132,7 @@ ALL_LIPID_CLASSES = {
     "Sulfatide",
     "Taurine",
     "TG",  # 70
-    "OAcylCeramide",
-    "RetinylE"
+    "OAcylCeramide"
 }
 
 
@@ -1017,7 +1016,7 @@ class singleAcyl(Lipid):
         chain_sets.append([c1])
 
 
-# CL, LysoCL
+# CL
 class CardioLipin(Lipid):
     chain1_ranges = []
     for c in [2] + list(range(14, 26, 2)):
@@ -1048,10 +1047,10 @@ class CardioLipin(Lipid):
                     # if (c2[0] == c1[0] and c2[1] < c1[0]): continue
                     # if c4[0] < c3[0]: continue
                     # if (c4[0] == c3[0] and c3[1] < c1[0]): continue
-                    # if (c3[0] < c1[0] or (c3[0] == c1[0] and c3[1] < c3[1])): continue # use for Maven, but not database
+                    # if (c3[0] < c1[0] or (c3[0] == c1[0] and c3[1] < c3[1])):
                     chain_sets.append([c1, c2, c3, c4])
 
-
+#LysoCL
 class LysoCardioLipin(Lipid):
     chain1_ranges = []
     for c in [2] + list(range(14, 26, 2)):
@@ -1072,10 +1071,7 @@ class LysoCardioLipin(Lipid):
                 if c3[0] < c2[0]: continue
                 if (c3[0] == c2[0] and c3[1] < c2[1]): continue
                 if c3[0] < c2[0]: continue
-                # if c2[0] < c1[0]: continue
-                # if (c2[0] == c1[0] and c2[1] < c1[0]): continue
-                # if c3[0] < c2[0]: continue
-                # if (c3[0] == c2[0] and c3[1] < c1[0]): continue
+
                 chain_sets.append([c1, c2, c3])
 
 


### PR DESCRIPTION
### Description of your changes
1.  Added make_smiles.py which makes class specfic SMILES strings for each lipid class. Note, FAHFA is the only exception, which should still have blank SMILES strings.  There are many isomers of e.g. FAHFA(18:0/18:0) and I was unsure which one to try to apply here.  
3. Added the smiles strings to each entry generated in the MSP.
4. Removed impossible structures (m-LCBs with a head group or t-LCBs with a double bond).  
5. In PrintNist, check to see if there are fragments, and if not, do not print the entry to the file.  
6. I found errors in several of the classses of gangliosides around the molecular formulas of the head groups, which I fixed.  
7. Most stereocenters are defined in the strings, but occasionally I have a hydroxyl on the LCB of sphingolipids defined without stereochemistry.  This could potentially be fixed in the future.  


### Issue ticket number and link
Resolves #9, Resolves #11 and resolves #10 


### Type of change
- [ ] Bug fix
- [X] New feature
   - [ ] Backwards Incompatible?
- [ ] Refactoring / code clean-up
- [ ] Documentation add / update
- [ ] Automated Test
- [ ] Other (please specify)

### (If applicable) How has this been tested?
I ran tests to make sure the SMILES molecular formulas matched the molecular fomulas being produced by the rest of the script (see above).
I also generated images of at least one lipid per lipid class and manually inspected it to make sure nothing was obviously wrong.  I did not investigate to the point that I know e.g. sugar sterochemistry or linkages are correct.  


