### PR TITLE
Read in a TSV with retention times, and add them to MSP output

### DIFF
--- a/calicolipidlibrary/LysoCL.py
+++ b/calicolipidlibrary/LysoCL.py
@@ -96,25 +96,25 @@ class LysoCL(LysoCardioLipin):
 
         return FRAGMENTS
 
-    def generateLibrary(self, target=None, mode="pos"):
-        if target:
-            handle = open(target, "a+")
-        if mode == "pos":
-            adduct_set = self.pos_adduct_set
-        elif mode == "neg":
-            adduct_set = self.neg_adduct_set
-        # parent = self.__bases__[0]
-        class_name = self.__class__.__name__
-        for c in self.chain_sets:
-            for adduct in adduct_set:
-                self.set_chains_and_adduct(class_name, c[:3], adduct=adduct)
-                content = self.printNist()
-                if target:
-                    handle.write(content)
-                else:
-                    sys.stdout.write(content)
-        if target:
-            handle.close()
+    # def generateLibrary(self, target=None, mode="pos", retention_times):
+    #     if target:
+    #         handle = open(target, "a+")
+    #     if mode == "pos":
+    #         adduct_set = self.pos_adduct_set
+    #     elif mode == "neg":
+    #         adduct_set = self.neg_adduct_set
+    #     # parent = self.__bases__[0]
+    #     class_name = self.__class__.__name__
+    #     for c in self.chain_sets:
+    #         for adduct in adduct_set:
+    #             self.set_chains_and_adduct(class_name, c[:3], adduct=adduct)
+    #             content = self.printNist(retention_times)
+    #             if target:
+    #                 handle.write(content)
+    #             else:
+    #                 sys.stdout.write(content)
+    #     if target:
+    #         handle.close()
 
 
 # x  = LysoCL("LysoCL",[[16,0,0], [18,1,0], [18,2,0]],  adduct="[M+H]+")


### PR DESCRIPTION
Added ability to read in a TSV with retention times, and add them to the output .msp.  Also found that the LysoCL class had a class specific generate fragments function, which I removed as it was redundant. Updated masses to more accurate values for H2O, NH3 and ELECTRON.  

### Description of your changes
<!--- Changes proposed in this pull request -->

### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->

### Type of change
- [ ] Bug fix
- [x] New feature
   - [ ] Backwards Incompatible?
- [ ] Refactoring / code clean-up
- [ ] Documentation add / update
- [ ] Automated Test
- [ ] Other (please specify)

### (If applicable) How has this been tested?
<!--- Please describe the tests that you ran to verify your changes. -->
<!--- Include details of your testing environment -->
